### PR TITLE
Add site content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
+title: "CodeAnalysis: Standard Java annotations for static analysis"
 theme: jekyll-theme-cayman
 github:
   is_project_page: false

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    {% if site.google_analytics %}
+      <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '{{ site.google_analytics }}');
+      </script>
+    {% endif %}
+    <meta charset="UTF-8">
+
+{% seo %}
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#157878">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+  </head>
+  <body>
+    <header class="page-header" role="banner">
+      <h1 class="project-name">{{ site.title | default: site.github.repository_name }}</h1>
+      <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
+      {% if site.github.is_project_page %}
+        <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
+      {% endif %}
+      {% if site.show_downloads %}
+        <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>
+        <a href="{{ site.github.tar_url }}" class="btn">Download .tar.gz</a>
+      {% endif %}
+    </header>
+
+    <main id="content" class="main-content" role="main">
+      {{ content }}
+    </main>
+  </body>
+</html>

--- a/index.md
+++ b/index.md
@@ -1,1 +1,47 @@
-Testing
+# Our Goal
+
+Java static analysis tools, such as Error Prone and those built into IDEs, have
+been very successful at enabling automated refactorings and bug prevention. Many
+of their most beneficial analyses require certain Java annotations (such as
+`@Nullable` or `@Immutable`) to be present in the source or class file. Yet for
+the 15 years since Java annotations were introduced (five years for type-use
+annotations), users have never had a clear answer for which incarnation of these
+annotation classes they can safely adopt. Many such artifacts have been created,
+but there has never been a serious and successful effort to provide **a single
+well-specified standard with industry consensus**. The lack of this artifact has
+constrained the prevalence and overall value of static analysis technology
+throughout the industry. It has encouraged today's tools to accept a wide
+variety of annotations, treating them equivalently, which renders the annotation
+specifications meaningless (an API owner cannot know whether applying a
+particular annotation is correct without knowing which tool its users will be
+using to interpret them). Finally, it complicates interoperation between Java
+and other JVM languages, which sometimes expect additional API metadata (such as
+nullability) that the Java language can't express. This missing artifact, with
+full specifications, is what we are working to create.[^1]
+
+[^1]: We have seen the xkcd comic. Please do not send us the xkcd comic. We know
+    about the xkcd comic.
+
+<!-- TODO(eaftan): add links to JVMLS talk, requirements doc & design docs
+     when they are ready -->
+
+# Participants
+
+People from the following projects and organizations are collaborating on
+this project:
+
+Project           | Organization
+----------------- | ------------
+Android           | Google
+Checker Framework |
+Eclipse           |
+Error Prone       | Google
+Guava             | Google
+IntelliJ IDEA     | JetBrains
+Kotlin            | JetBrains
+NullAway          | Uber
+Pivotal           | Spring
+PMD               |
+SpotBugs          |
+                  | SonarSource
+                  | Square

--- a/index.md
+++ b/index.md
@@ -42,7 +42,7 @@ Kotlin            | JetBrains
 NullAway          | Uber
 Pivotal           | Spring
 PMD               |
-SpotBugs          |
+[SpotBugs](http://spotbugs.rtfd.io/)          | [SpotBugs Team](https://github.com/spotbugs/)
                   | SonarSource
                   | Square
 

--- a/index.md
+++ b/index.md
@@ -45,3 +45,7 @@ PMD               |
 SpotBugs          |
                   | SonarSource
                   | Square
+
+# Contact info
+
+Email the group at <well-defined-annotations@googlegroups.com>.

--- a/index.md
+++ b/index.md
@@ -27,24 +27,24 @@ full specifications, is what we are working to create.[^1]
 
 # Participants
 
-People from the following projects and organizations are collaborating on
-this project:
+People from the following projects and organizations are collaborating on this
+project:
 
-Project           | Organization
------------------ | ------------
-Android           | Google
-Checker Framework |
-Eclipse           |
-Error Prone       | Google
-Guava             | Google
-IntelliJ IDEA     | JetBrains
-Kotlin            | JetBrains
-NullAway          | Uber
-Pivotal           | Spring
-PMD               |
-[SpotBugs](http://spotbugs.rtfd.io/)          | [SpotBugs Team](https://github.com/spotbugs/)
-SonarQube | SonarSource
-                  | Square
+Project                                           | Organization
+------------------------------------------------- | ------------
+[Android](https://www.android.com)                | [Google](https://google.com)
+[Checker Framework](https://checkerframework.org) |
+[Eclipse IDE](https://www.eclipse.org/ide/)       | [Eclipse Foundation](https://www.eclipse.org/)
+[Error Prone](https://errorprone.info)            | [Google](https://google.com)
+[Guava](https://github.com/google/guava)          | [Google](https://google.com)
+[IntelliJ IDEA](https://www.jetbrains.com/idea/)  | [JetBrains](https://www.jetbrains.com/)
+[Kotlin](https://kotlinlang.org/)                 | [JetBrains](https://www.jetbrains.com/)
+[NullAway](https://github.com/uber/NullAway)      | [Uber](https://uber.com)
+[PMD](https://pmd.github.io/)                     |
+[Spring](https://pivotal.io/spring-app-framework) | [Pivotal](https://pivotal.io)
+[SonarQube](https://www.sonarqube.org/)           | [SonarSource](https://www.sonarsource.com/)
+[SpotBugs](http://spotbugs.rtfd.io/)              | [SpotBugs Team](https://github.com/spotbugs/)
+                                                  | [Square](https://squareup.com)
 
 # Contact info
 

--- a/index.md
+++ b/index.md
@@ -43,7 +43,7 @@ NullAway          | Uber
 Pivotal           | Spring
 PMD               |
 [SpotBugs](http://spotbugs.rtfd.io/)          | [SpotBugs Team](https://github.com/spotbugs/)
-                  | SonarSource
+SonarQube | SonarSource
                   | Square
 
 # Contact info


### PR DESCRIPTION
I pulled most of the content from @kevinb9n's general requirements doc.  I added a list of participating projects and organizations to show that this has wide support from across the Java community.

I'd appreciate feedback on the formatting of the participant list.  

Here's a screenshot of what the site will look like when this gets merged: 

![UKfeT30eedH](https://user-images.githubusercontent.com/4733401/61987265-0134c180-afca-11e9-98ac-6d72b790560a.png)
