### PR TITLE
Define a JPMS module for our annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,13 +3,11 @@ plugins {
     id 'maven-publish'
     id 'com.diffplug.gradle.spotless' version '3.28.1'
     id 'net.ltgt.errorprone' version '1.1.1'
+    id 'org.javamodularity.moduleplugin' version '1.6.0'
 }
 
 apply from: "$rootDir/gradle/format.gradle"
 apply from: "$rootDir/gradle/publish.gradle"
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
 
 repositories { mavenCentral() }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -24,3 +24,7 @@ publishing {
         }
     }
 }
+
+// compile module-info.java with Java9, and others with Java8
+// https://github.com/java9-modularity/gradle-modules-plugin#separate-compilation-of-module-infojava
+modularity.mixedJavaRelease 8

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module jspecify.annotations {
+  exports org.jspecify.experimentaldonotuse;
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,3 +1,3 @@
-module jspecify.annotations {
+module org.jspecify.experimentaldonotuse {
   exports org.jspecify.experimentaldonotuse;
 }


### PR DESCRIPTION
Apply [gradle-modules-plugin](https://github.com/java9-modularity/gradle-modules-plugin) and replace existing configurations with [`modularity.mixedJavaRelease` which configures `--release` javac option](https://github.com/java9-modularity/gradle-modules-plugin#separate-compilation-of-module-infojava).

close #104

### javap result of module-info

```
Classfile .../jspecify/build/libs/module-info.class
  Last modified Apr 26, 2020; size 204 bytes
  MD5 checksum e57e5ad61b984f5ef27b6583a6230f74
  Compiled from "module-info.java"
module jspecify.annotations
  minor version: 0
  major version: 53
```

Major version 53 means Java 9.

### javap result of Nullable
```
Classfile .../jspecify/build/libs/org/jspecify/experimentaldonotuse/Nullable.class
  Last modified Apr 26, 2020; size 443 bytes
  MD5 checksum 3457a0b34780144765f79960198c4c42
  Compiled from "Nullable.java"
public interface org.jspecify.experimentaldonotuse.Nullable extends java.lang.annotation.Annotation
  minor version: 0
  major version: 52
```

Major version 52 means Java 8.