### PR TITLE
Rename package and module, to prepare for install and deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK 11 # to use compile-time analysis by Errorprone
         uses: actions/setup-java@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -24,4 +24,9 @@ dependencies {
 
 test { useJUnitPlatform() }
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 defaultTasks 'spotlessApply', 'build'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -4,8 +4,9 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             pom {
-                groupId = 'org.jspecify.annotations'
-                name = 'jspecify'
+                groupId = 'org.jspecify'
+                artifactId = 'annotations'
+                name = 'jspecify annotations'
                 description = 'An artifact of well-named and well-specified annotations to power static analysis checks'
                 url = 'https://jspecify.org/'
                 from components.java

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -4,7 +4,7 @@ publishing {
     publications {
         mavenJava(MavenPublication) {
             pom {
-                groupId = 'org.jspecify.experimentaldonotuse'
+                groupId = 'org.jspecify.annotations'
                 name = 'jspecify'
                 description = 'An artifact of well-named and well-specified annotations to power static analysis checks'
                 url = 'https://jspecify.org/'

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,3 +1,3 @@
-module org.jspecify.experimentaldonotuse {
-  exports org.jspecify.experimentaldonotuse;
+module org.jspecify.annotations {
+  exports org.jspecify.annotations;
 }

--- a/src/main/java/org/jspecify/annotations/DefaultNonNull.java
+++ b/src/main/java/org/jspecify/annotations/DefaultNonNull.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jspecify.experimentaldonotuse;
+package org.jspecify.annotations;
 
-import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.ElementType.PACKAGE;
+import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.CLASS;
 
 import java.lang.annotation.Documented;
@@ -23,6 +24,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 @Documented
-@Target(TYPE_USE)
+@Target({TYPE, PACKAGE})
 @Retention(CLASS)
-public @interface Nullable {}
+public @interface DefaultNonNull {}

--- a/src/main/java/org/jspecify/annotations/Nullable.java
+++ b/src/main/java/org/jspecify/annotations/Nullable.java
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jspecify.experimentaldonotuse;
+package org.jspecify.annotations;
 
-import static java.lang.annotation.ElementType.PACKAGE;
-import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.CLASS;
 
 import java.lang.annotation.Documented;
@@ -24,6 +23,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 @Documented
-@Target({TYPE, PACKAGE})
+@Target(TYPE_USE)
 @Retention(CLASS)
-public @interface DefaultNonNull {}
+public @interface Nullable {}


### PR DESCRIPTION
Based on [this proposal](https://github.com/jspecify/jspecify/issues/1#issuecomment-620826847), rename package and module to `org.jspecify.annotations`.

In this branch, we can build and publish artifacts `org.jspecify:annotations:0.1.0-SNAPSHOT` like below:

```
$ ./gradlew publishToMavenLocal
$ ls -1R ~/.m2/repository/org/jspecify
annotations

~/.m2/repository/org/jspecify/annotations:
0.1.0-SNAPSHOT
maven-metadata-local.xml

~/.m2/repository/org/jspecify/annotations/0.1.0-SNAPSHOT:
annotations-0.1.0-SNAPSHOT-javadoc.jar
annotations-0.1.0-SNAPSHOT-sources.jar
annotations-0.1.0-SNAPSHOT.jar
annotations-0.1.0-SNAPSHOT.module
annotations-0.1.0-SNAPSHOT.pom
maven-metadata-local.xml
```