### PR TITLE
Update the target branch name to build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Sphinx Document
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     paths:
       - 'docs/**'


### PR DESCRIPTION
We changed the default branch from `master` to `main`, so we need to use `main` in the `docs.yml` file.