### PR TITLE
Link to the new page from the site top

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,6 @@
 jspecify: Standard Java annotations for static analysis
 =======================================================
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
 Our Goal
 --------
 
@@ -61,6 +57,12 @@ People from the following projects and organizations are collaborating on this p
 |                                                    | `Square <https://squareup.com>`_                |
 +----------------------------------------------------+-------------------------------------------------+
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Contents
+
+   tsttcpw
+
 Contact Info
 ------------
 
@@ -71,3 +73,4 @@ Indices and searches
 
 * :ref:`genindex`
 * :ref:`search`
+


### PR DESCRIPTION
[The newly added page](https://jspecify.dev/tsttcpw.html) is not linked from the site top.
This PR suggests to link it from the side menu.

### How the link will be available

<img width="821" alt="Screen Shot 2020-09-12 at 19 31 48" src="https://user-images.githubusercontent.com/505751/92994650-be67dd00-f52e-11ea-81d5-76a27fe2f29c.png">

