### PR TITLE
Use fixed github-pages-deploy-action version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           name: document
           path: docs/_build/html
 
-      - uses: JamesIves/github-pages-deploy-action@releases/v3
+      - uses: JamesIves/github-pages-deploy-action@3.6.2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
in an attempt to fix https://github.com/jspecify/jspecify/runs/1200508024
(And to see whether the CLA works.)
Not sure whether this is the right fix, though.