### PR TITLE
Remove false positive warnings

### DIFF
--- a/samples/NullCheck.java
+++ b/samples/NullCheck.java
@@ -20,16 +20,6 @@ import org.jspecify.annotations.NullnessUnspecified;
 
 @DefaultNonNull
 class NullCheck {
-  // TODO(cpovirk): Soften README to permit flow-sensitive samples in moderation.
-  Object x0(Object o) {
-    if (o != null) {
-      return o;
-    } else {
-      // jspecify_nullness_mismatch
-      return o;
-    }
-  }
-
   Object x1(@NullnessUnspecified Object o) {
     if (o != null) {
       return o;
@@ -44,15 +34,6 @@ class NullCheck {
       return o;
     } else {
       // jspecify_nullness_mismatch
-      return o;
-    }
-  }
-
-  Object x3(Object o) {
-    if (o == null) {
-      // jspecify_nullness_mismatch
-      return o;
-    } else {
       return o;
     }
   }

--- a/samples/NullCheck.java
+++ b/samples/NullCheck.java
@@ -20,6 +20,7 @@ import org.jspecify.annotations.NullnessUnspecified;
 
 @DefaultNonNull
 class NullCheck {
+  // TODO(cpovirk): Soften README to permit flow-sensitive samples in moderation.
   Object x1(@NullnessUnspecified Object o) {
     if (o != null) {
       return o;

--- a/samples/NullCheckTypeVariable.java
+++ b/samples/NullCheckTypeVariable.java
@@ -20,15 +20,6 @@ import org.jspecify.annotations.NullnessUnspecified;
 
 @DefaultNonNull
 class NullCheckTypeVariable<T> {
-  Object x0(T o) {
-    if (o != null) {
-      return o;
-    } else {
-      // jspecify_nullness_mismatch
-      return o;
-    }
-  }
-
   Object x1(@NullnessUnspecified T o) {
     if (o != null) {
       return o;
@@ -43,15 +34,6 @@ class NullCheckTypeVariable<T> {
       return o;
     } else {
       // jspecify_nullness_mismatch
-      return o;
-    }
-  }
-
-  Object x3(T o) {
-    if (o == null) {
-      // jspecify_nullness_mismatch
-      return o;
-    } else {
       return o;
     }
   }


### PR DESCRIPTION
These test cases mandate a false positive warning in correct code.
We don't want our test cases to contain false positive warnings that not all checkers will issue.

In the future, they could be added with a different (non-normative) tag.  In the meanwhile, I think it is better to remove them rather than have a broken test suite.