### PR TITLE
For Javadoc jar, prefer Java 9+ sources over Java 8.

### DIFF
--- a/gradle/mrjar.gradle
+++ b/gradle/mrjar.gradle
@@ -27,3 +27,8 @@ jar {
         attributes 'Multi-Release': true
     }
 }
+
+javadoc {
+    // Prefer the copy of DefaultNonNull whose @Target includes MODULE.
+    source = sourceSets.java9.allJava + sourceSets.main.allJava
+}


### PR DESCRIPTION
This handles the Javadoc half of https://github.com/jspecify/jspecify/issues/179