### PR TITLE
Resolve warning of the document generation with markdown

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'README.md']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -334,7 +334,6 @@ to expression typing.
 [base type]: https://docs.google.com/document/d/1KQrBxwaVIPIac_6SCf--w-vZBeHkTvtaqPSU_icIccc/edit#bookmark=kix.k81vs7t5p45i
 [base types]: https://docs.google.com/document/d/1KQrBxwaVIPIac_6SCf--w-vZBeHkTvtaqPSU_icIccc/edit#bookmark=kix.k81vs7t5p45i
 [capture conversion]: #capture-conversion
-[containment]: #containment
 [glossary]: https://docs.google.com/document/d/1KQrBxwaVIPIac_6SCf--w-vZBeHkTvtaqPSU_icIccc/edit
 [implementation code]: https://docs.google.com/document/d/1KQrBxwaVIPIac_6SCf--w-vZBeHkTvtaqPSU_icIccc/edit#bookmark=id.cjuxrgo7keqs
 [intersection type]: #intersection-types

--- a/docs/design-overview.md
+++ b/docs/design-overview.md
@@ -90,7 +90,7 @@ nullability.
     -   a type of unspecified nullness where a subtype of unspecified nullness
         is required
 
--   For usability reasons, many tools will not generate generate warnings/errors
+-   For usability reasons, many tools will not generate warnings/errors
     when applying unsound rules like those above. Others may generate them
     optionally, likely with the warnings/errors off by default. Even when a tool
     does report these warnings/errors, we **strongly** encourage the tool to

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -764,7 +764,6 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 [base type]: https://docs.google.com/document/d/1KQrBxwaVIPIac_6SCf--w-vZBeHkTvtaqPSU_icIccc/edit#bookmark=kix.k81vs7t5p45i
 [base types]: https://docs.google.com/document/d/1KQrBxwaVIPIac_6SCf--w-vZBeHkTvtaqPSU_icIccc/edit#bookmark=kix.k81vs7t5p45i
 [capture conversion]: #capture-conversion
-[containment]: #containment
 [design overview]: design-overview
 [glossary]: https://docs.google.com/document/d/1KQrBxwaVIPIac_6SCf--w-vZBeHkTvtaqPSU_icIccc/edit
 [implementation code]: https://docs.google.com/document/d/1KQrBxwaVIPIac_6SCf--w-vZBeHkTvtaqPSU_icIccc/edit#bookmark=id.cjuxrgo7keqs


### PR DESCRIPTION
This PR suggests fixing several warnings and duplicated word in the doc:

1. Stop building `README.md` as a part of the landing page; now it's available at https://jspecify.dev/README.html
2. Remove duplicated reference `CONTAINMENT` in `spec.md` and `design-overview.md`
3. Remove duplicated "genearte "

Thanks for your review! :)