### PR TITLE
Candidates for minimalist javadoc in 0.2.0

### DIFF
--- a/src/java9/java/org/jspecify/nullness/NullMarked.java
+++ b/src/java9/java/org/jspecify/nullness/NullMarked.java
@@ -25,14 +25,18 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * <b>WARNING:</b> This is not the final class name or package name for this annotation. In
- * addition, we are still discussing questions about semantics, particularly around type-variable
- * usages. After that, changes and documentation will follow.
+ * Indicates that within the annotated scope (class, package, or module), type usages
+ * <i>generally</i> do <i>not</i> include {@code null} as a value, unless they are individually
+ * marked otherwise.  Without this annotation, these type usages would instead have <i>unspecified
+ * nullness</i>. Several exceptions to this rule and an explanation of unspecified nullness are
+ * covered in the <a href="https://jspecify.dev/user-guide">JSpecify User Guide</a>.
  *
- * <p>These annotations exist only as a skeleton for the final product. At this point, we are not
- * even building prototypes that use them.
+ * <p><b>WARNING: Do not release libraries using this annotation at this time.</b> It is under
+ * development, and <i>any</i> aspect of its naming, location, or design may change before 1.0.
  */
 @Documented
 @Target({TYPE, PACKAGE, MODULE})
 @Retention(RUNTIME)
-public @interface NullMarked {}
+public @interface NullMarked {
+  // note for maintainers: When you update this file, please update the file in src/java9 too.
+}

--- a/src/java9/java/org/jspecify/nullness/NullMarked.java
+++ b/src/java9/java/org/jspecify/nullness/NullMarked.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
 /**
  * Indicates that within the annotated scope (class, package, or module), type usages
  * <i>generally</i> do <i>not</i> include {@code null} as a value, unless they are individually
- * marked otherwise.  Without this annotation, these type usages would instead have <i>unspecified
+ * marked otherwise. Without this annotation, these type usages would instead have <i>unspecified
  * nullness</i>. Several exceptions to this rule and an explanation of unspecified nullness are
  * covered in the <a href="https://jspecify.dev/user-guide">JSpecify User Guide</a>.
  *

--- a/src/java9/java/org/jspecify/nullness/NullMarked.java
+++ b/src/java9/java/org/jspecify/nullness/NullMarked.java
@@ -38,5 +38,5 @@ import java.lang.annotation.Target;
 @Target({TYPE, PACKAGE, MODULE})
 @Retention(RUNTIME)
 public @interface NullMarked {
-  // note for maintainers: When you update this file, please update the file in src/java9 too.
+  // note for maintainers: When you update this file, please update the file in src/main too.
 }

--- a/src/main/java/org/jspecify/nullness/NullMarked.java
+++ b/src/main/java/org/jspecify/nullness/NullMarked.java
@@ -24,12 +24,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * <b>WARNING:</b> This is not the final class name or package name for this annotation. In
- * addition, we are still discussing questions about semantics, particularly around type-variable
- * usages. After that, changes and documentation will follow.
+ * Indicates that within the annotated scope (class or package), type usages
+ * <i>generally</i> do <i>not</i> include {@code null} as a value, unless they are individually
+ * marked otherwise.  Without this annotation, these type usages would instead have <i>unspecified
+ * nullness</i>. Several exceptions to this rule and an explanation of unspecified nullness are
+ * covered in the <a href="https://jspecify.dev/user-guide">JSpecify User Guide</a>.
  *
- * <p>These annotations exist only as a skeleton for the final product. At this point, we are not
- * even building prototypes that use them.
+ * <p><b>WARNING: Do not release libraries using this annotation at this time.</b> It is under
+ * development, and <i>any</i> aspect of its naming, location, or design may change before 1.0.
  */
 @Documented
 @Target({TYPE, PACKAGE})

--- a/src/main/java/org/jspecify/nullness/Nullable.java
+++ b/src/main/java/org/jspecify/nullness/Nullable.java
@@ -23,12 +23,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * Indicates that the annotated type usage includes {@code null} as a value. See <a
- * href="https://jspecify.dev/user-guide">the JSpecify User Guide</a> for details.
+ * Indicates that the annotated type usage includes {@code null} as a value. To understand the
+ * nullness of nearby <i>unannotated</i> type usages, check for {@link NullMarked} on the enclosing
+ * class, package, or module. See the <a href="https://jspecify.dev/user-guide">JSpecify User
+ * Guide</a> for details.
  *
- * <p><b>WARNING:</b> We have not finalized the package name for this annotation. In addition, we
- * are still discussing questions about semantics, particularly around type-variable usages. After
- * that, changes and further documentation will follow.
+ * <p><b>WARNING: Do not release libraries using this annotation at this time.</b> It is under
+ * development, and <i>any</i> aspect of its naming, location, or design may change before 1.0.
  */
 @Documented
 @Target(TYPE_USE)

--- a/src/main/java/org/jspecify/nullness/Nullable.java
+++ b/src/main/java/org/jspecify/nullness/Nullable.java
@@ -24,9 +24,9 @@ import java.lang.annotation.Target;
 
 /**
  * Indicates that the annotated type usage includes {@code null} as a value. To understand the
- * nullness of nearby <i>unannotated</i> type usages, check for {@link NullMarked} on the enclosing
- * class, package, or module. See the <a href="https://jspecify.dev/user-guide">JSpecify User
- * Guide</a> for details.
+ * nullness of <i>unannotated</i> type usages, check for {@link NullMarked} on the enclosing class,
+ * package, or module. See the <a href="https://jspecify.dev/user-guide">JSpecify User Guide</a> for
+ * details.
  *
  * <p><b>WARNING: Do not release libraries using this annotation at this time.</b> It is under
  * development, and <i>any</i> aspect of its naming, location, or design may change before 1.0.

--- a/src/main/java/org/jspecify/nullness/NullnessUnspecified.java
+++ b/src/main/java/org/jspecify/nullness/NullnessUnspecified.java
@@ -23,8 +23,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * <b>This annotation is not planned for inclusion in JSpecify 1.0</b>, unless
- * <a href="https://github.com/jspecify/jspecify/issues/137">this issue</a> is reopened and resolved
+ * <b>This annotation is not planned for inclusion in JSpecify 1.0</b>, unless <a
+ * href="https://github.com/jspecify/jspecify/issues/137">this issue</a> is reopened and resolved
  * favorably. It's here temporarily until some tests are fixed, and in the meantime we will be
  * deleting it from any release branch we start.
  */

--- a/src/main/java/org/jspecify/nullness/NullnessUnspecified.java
+++ b/src/main/java/org/jspecify/nullness/NullnessUnspecified.java
@@ -23,10 +23,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * <b>This annotation is not planned for inclusion in JSpecify 1.0</b>, unless <a
- * href="https://github.com/jspecify/jspecify/issues/137">this issue is reopened and resolved
+ * <b>This annotation is not planned for inclusion in JSpecify 1.0</b>, unless
+ * <a href="https://github.com/jspecify/jspecify/issues/137">this issue</a> is reopened and resolved
  * favorably. It's here temporarily until some tests are fixed, and in the meantime we will be
- * deleting from any release branch we start.
+ * deleting it from any release branch we start.
  */
 @Documented
 @Target(TYPE_USE)

--- a/src/main/java/org/jspecify/nullness/NullnessUnspecified.java
+++ b/src/main/java/org/jspecify/nullness/NullnessUnspecified.java
@@ -23,11 +23,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * <b>WARNING:</b> This is not the final class name or package name for this annotation. We are not
- * even sure if an annotation like this one will make the 1.0 release.
- *
- * <p>These annotations exist only as a skeleton for the final product. At this point, we are not
- * even building prototypes that use them.
+ * <b>This annotation is not planned for inclusion in JSpecify 1.0</b>, unless <a
+ * href="https://github.com/jspecify/jspecify/issues/137">this issue is reopened and resolved
+ * favorably. It's here temporarily until some tests are fixed, and in the meantime we will be
+ * deleting from any release branch we start.
  */
 @Documented
 @Target(TYPE_USE)


### PR DESCRIPTION
I want to propose keeping the javadoc as short as possible, just for 0.2.0. Here is one take on that.