### PR TITLE
Remove mention of module scope

### DIFF
--- a/src/main/java/org/jspecify/nullness/Nullable.java
+++ b/src/main/java/org/jspecify/nullness/Nullable.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
 
 /**
  * Indicates that the annotated type usage includes {@code null} as a value. To understand the
- * nullness of <i>unannotated</i> type usages, check for {@link NullMarked} on the enclosing class,
- * package, or module. See the <a href="https://jspecify.dev/user-guide">JSpecify User Guide</a> for
+ * nullness of <i>unannotated</i> type usages, check for {@link NullMarked} on the enclosing class
+ * or package. See the <a href="https://jspecify.dev/user-guide">JSpecify User Guide</a> for
  * details.
  *
  * <p><b>WARNING: Do not release libraries using this annotation at this time.</b> It is under


### PR DESCRIPTION
`@NullMarked` is currently only for types and packages, not modules.
See https://github.com/jspecify/jspecify/blob/da837510bcea361c41bb8eea458e8de26cbab91b/src/main/java/org/jspecify/nullness/NullMarked.java#L37 and #34.