### PR TITLE
Use jspecify.org

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -64,7 +64,7 @@ the following line.
 
 The first three special comments indicate that JSpecify annotations are applied
 in ways that are
-[unrecognized](https://jspecify.dev/spec.html#recognized-locations-type-use).
+[unrecognized](https://jspecify.org/spec.html#recognized-locations-type-use).
 Tools are likely to report an error in the case of the first two, somewhat less
 likely to report an error in the case of the third (since they might choose to
 give their meaning to annotations there), and not *obligated* to do anything for

--- a/src/java9/java/org/jspecify/nullness/NullMarked.java
+++ b/src/java9/java/org/jspecify/nullness/NullMarked.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  * <i>generally</i> do <i>not</i> include {@code null} as a value, unless they are individually
  * marked otherwise. Without this annotation, these type usages would instead have <i>unspecified
  * nullness</i>. Several exceptions to this rule and an explanation of unspecified nullness are
- * covered in the <a href="https://jspecify.dev/user-guide">JSpecify User Guide</a>.
+ * covered in the <a href="https://jspecify.org/user-guide">JSpecify User Guide</a>.
  *
  * <p><b>WARNING: Do not release libraries using this annotation at this time.</b> It is under
  * development, and <i>any</i> aspect of its naming, location, or design may change before 1.0.

--- a/src/main/java/org/jspecify/nullness/NullMarked.java
+++ b/src/main/java/org/jspecify/nullness/NullMarked.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * <i>generally</i> do <i>not</i> include {@code null} as a value, unless they are individually
  * marked otherwise.  Without this annotation, these type usages would instead have <i>unspecified
  * nullness</i>. Several exceptions to this rule and an explanation of unspecified nullness are
- * covered in the <a href="https://jspecify.dev/user-guide">JSpecify User Guide</a>.
+ * covered in the <a href="https://jspecify.org/user-guide">JSpecify User Guide</a>.
  *
  * <p><b>WARNING: Do not release libraries using this annotation at this time.</b> It is under
  * development, and <i>any</i> aspect of its naming, location, or design may change before 1.0.

--- a/src/main/java/org/jspecify/nullness/Nullable.java
+++ b/src/main/java/org/jspecify/nullness/Nullable.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * Indicates that the annotated type usage includes {@code null} as a value. To understand the
  * nullness of <i>unannotated</i> type usages, check for {@link NullMarked} on the enclosing class,
- * package, or module. See the <a href="https://jspecify.dev/user-guide">JSpecify User Guide</a> for
+ * package, or module. See the <a href="https://jspecify.org/user-guide">JSpecify User Guide</a> for
  * details.
  *
  * <p><b>WARNING: Do not release libraries using this annotation at this time.</b> It is under


### PR DESCRIPTION
How do people feel about using `jspecify.org` for links, to be consistent with the package name?
The link will automatically redirect to `jspecify.dev`.
(Also needs to be done in other files.)