### PR TITLE
Generalize warning

### DIFF
--- a/src/java9/java/org/jspecify/nullness/NullMarked.java
+++ b/src/java9/java/org/jspecify/nullness/NullMarked.java
@@ -31,8 +31,9 @@ import java.lang.annotation.Target;
  * nullness</i>. Several exceptions to this rule and an explanation of unspecified nullness are
  * covered in the <a href="http://jspecify.org/user-guide">JSpecify User Guide</a>.
  *
- * <p><b>WARNING: Do not release libraries using this annotation at this time.</b> It is under
- * development, and <i>any</i> aspect of its naming, location, or design may change before 1.0.
+ * <p><b>WARNING:</b> This annotation is under development, and <i>any</i> aspect of its naming,
+ * location, or design may change before 1.0. <b>Do not release libraries using this annotation at
+ * this time.</b>
  */
 @Documented
 @Target({TYPE, PACKAGE, MODULE})

--- a/src/main/java/org/jspecify/nullness/NullMarked.java
+++ b/src/main/java/org/jspecify/nullness/NullMarked.java
@@ -30,8 +30,9 @@ import java.lang.annotation.Target;
  * Several exceptions to this rule and an explanation of unspecified nullness are covered in the <a
  * href="http://jspecify.org/user-guide">JSpecify User Guide</a>.
  *
- * <p><b>WARNING: Do not release libraries using this annotation at this time.</b> It is under
- * development, and <i>any</i> aspect of its naming, location, or design may change before 1.0.
+ * <p><b>WARNING:</b> This annotation is under development, and <i>any</i> aspect of its naming,
+ * location, or design may change before 1.0. <b>Do not release libraries using this annotation at
+ * this time.</b>
  */
 @Documented
 @Target({TYPE, PACKAGE})

--- a/src/main/java/org/jspecify/nullness/Nullable.java
+++ b/src/main/java/org/jspecify/nullness/Nullable.java
@@ -28,8 +28,9 @@ import java.lang.annotation.Target;
  * package, or module. See the <a href="https://jspecify.dev/user-guide">JSpecify User Guide</a> for
  * details.
  *
- * <p><b>WARNING: Do not release projects using this annotation at this time.</b> It is under
+ * <p><b>WARNING:</b> This annotation is under
  * development, and <i>any</i> aspect of its naming, location, or design may change before 1.0.
+ * <b>Do not release libraries using this annotation at this time.</b>
  */
 @Documented
 @Target(TYPE_USE)

--- a/src/main/java/org/jspecify/nullness/Nullable.java
+++ b/src/main/java/org/jspecify/nullness/Nullable.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * package, or module. See the <a href="https://jspecify.dev/user-guide">JSpecify User Guide</a> for
  * details.
  *
- * <p><b>WARNING: Do not release libraries using this annotation at this time.</b> It is under
+ * <p><b>WARNING: Do not release projects using this annotation at this time.</b> It is under
  * development, and <i>any</i> aspect of its naming, location, or design may change before 1.0.
  */
 @Documented

--- a/src/main/java/org/jspecify/nullness/Nullable.java
+++ b/src/main/java/org/jspecify/nullness/Nullable.java
@@ -28,9 +28,9 @@ import java.lang.annotation.Target;
  * package, or module. See the <a href="http://jspecify.org/user-guide">JSpecify User Guide</a> for
  * details.
  *
- * <p><b>WARNING:</b> This annotation is under
- * development, and <i>any</i> aspect of its naming, location, or design may change before 1.0.
- * <b>Do not release libraries using this annotation at this time.</b>
+ * <p><b>WARNING:</b> This annotation is under development, and <i>any</i> aspect of its naming,
+ * location, or design may change before 1.0. <b>Do not release libraries using this annotation at +
+ * * this time.</b>
  */
 @Documented
 @Target(TYPE_USE)


### PR DESCRIPTION
Instead of just warning about "libraries", should it be something more general, like "projects"?
Libraries are particularly affected, as others also depend on them. But the warning equally applies to somebody who just uses the annotations in their application.