### PR TITLE
Add a `developer` to the project metadata.

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -27,6 +27,13 @@ publishing {
                         name = 'Kevin Bourrillion'
                         email = 'kevinb@google.com'
                     }
+                    developer {
+                        id = 'KengoTODA'
+                        name = 'Kengo TODA'
+                        email = 'skypencil@gmail.com'
+                        url = 'https://github.com/KengoTODA/'
+                        timezone = '+8'
+                    }
                 }
             }
         }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -22,6 +22,8 @@ publishing {
                     url = 'https://github.com/jspecify/jspecify/'
                 }
                 developers {
+                    // These are here only because Sonatype requires us to list someone.
+                    // Any project member is welcome to add themselves if they want to.
                     developer {
                         id = 'kevinb9n'
                         name = 'Kevin Bourrillion'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -21,6 +21,13 @@ publishing {
                     developerConnection = 'scm:git:git@github.com:jspecify/jspecify.git'
                     url = 'https://github.com/jspecify/jspecify/'
                 }
+                developers {
+                    developer {
+                        id = 'kevinb9n'
+                        name = 'Kevin Bourrillion'
+                        email = 'kevinb@google.com'
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Instructions:
https://docs.gradle.org/current/userguide/publishing_maven.html#sec:modifying_the_generated_pom

Without this, we can't close the Sonatype repository: We get the error
"Developer information missing."

It's not clear who exactly we should list here. Probably we'd prefer
that people contact us on GitHub or our mailing list (if we've opened up
posting permission to everyone). For the moment, I've added only kevinb,
since he has plans to do some outreach to the wider community. If anyone
would like to be added, feel free to add yourself.