### PR TITLE
Allow build with JDK 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'java-library'
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
-    id 'com.diffplug.spotless' version '5.12.5'
-    id 'net.ltgt.errorprone' version '2.0.1'
+    id 'com.diffplug.spotless' version '5.14.3'
+    id 'net.ltgt.errorprone' version '2.0.2'
     id 'org.javamodularity.moduleplugin' version '1.8.7'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I tried building with the current JDK 17 release candidate and get an exception:

````
* What went wrong:
Could not compile settings file '/home/wdietl/Sync/wmdietl/workspaces/jspecify/jspecify/settings.gradle'.
> startup failed:
  General error during conversion: Unsupported class file major version 61
  
  java.lang.IllegalArgumentException: Unsupported class file major version 61
        at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:189)
        at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:170)
        at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:156)
        at groovyjarjarasm.asm.ClassReader.<init>(ClassReader.java:277)
````

The changes in this PR update gradle to 7.2 and update some plugin versions.
This now builds successfully with the JDK 17 RC1.

There are some deprecation warnings from gradle that I'm not sure how to fix.