### PR TITLE
Remove build warnings introduced by Gradle 7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
     id 'com.diffplug.spotless' version '5.14.3'
     id 'net.ltgt.errorprone' version '2.0.2'
-    id 'org.javamodularity.moduleplugin' version '1.8.7'
+    id 'org.javamodularity.moduleplugin' version '1.8.9'
 }
 
 ext {


### PR DESCRIPTION
Now builds in `main` print several warnings caused by the Gradle Modules plugin. It was introduced by Gradle v7.2 introduced by 6c3f28650dcb3843965f9691f05aa624ec300e56. So I've investigated and found a solution: java9-modularity/gradle-modules-plugin#201

The [updated version](https://github.com/java9-modularity/gradle-modules-plugin/releases/tag/v1.8.9) has been released yesterday, so I'm suggesting this PR that applies the released version to remove warnings. I've confirmed that this change has removed warnings during the build in [this workflow run](https://github.com/jspecify/jspecify/runs/3501654400).