### PR TITLE
Update actions in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,6 @@ jobs:
         with:
           distribution: adopt
           java-version: 11
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: gradle
       - run: |
           ./gradlew spotlessCheck build publishToMavenLocal --no-daemon

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,9 +24,8 @@ jobs:
           name: document
           path: docs/_build/html
 
-      - uses: JamesIves/github-pages-deploy-action@3.6.2
+      - uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: docs/_build/html
+          branch: gh-pages
+          folder: docs/_build/html
         if: github.event_name == 'push'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
           docker run --rm -v $(pwd)/docs:/docs jspecify-sphinx make -e SPHINXOPTS="-D language='ja'" -e BUILDDIR="_build-ja" html
           docker run --rm -v $(pwd)/docs:/docs jspecify-sphinx cp -R _build-ja/html _build/html/ja
 
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
           name: document
           path: docs/_build/html


### PR DESCRIPTION
Just minor updates for the workflows:

1. Apply the built-in cache feature of `actions/setup-java` to shorten the workflow definition. It's also expected to reduce the time to build. refs https://github.com/actions/setup-java/pull/193#issuecomment-901865758
2. `amesIves/github-pages-deploy-action` released v4, so followed its [migration guide](https://github.com/JamesIves/github-pages-deploy-action/discussions/592) to get updated and secure.
3. `actions/upload-artifact` released v2, just follow their changeto get updated and secure. No migration is needed.