### PR TITLE
Set javadoc encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,4 +34,8 @@ java {
     }
 }
 
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
 defaultTasks 'spotlessApply', 'build'


### PR DESCRIPTION
Recently, Checker Framework builds started failing with an error about encodings in JSpecify files:

````
> Task :javadoc FAILED
/__w/1/jspecify/src/main/java/org/jspecify/nullness/NullUnmarked.java:44: error: unmappable character (0xE2) for encoding US-ASCII
 * <p>Otherwise it is considered null-unmarked: whether that???s because it is more narrowly enclosed
                                                            ^
/__w/1/jspecify/src/main/java/org/jspecify/nullness/NullUnmarked.java:44: error: unmappable character (0x80) for encoding US-ASCII
 * <p>Otherwise it is considered null-unmarked: whether that???s because it is more narrowly enclosed
                                                             ^
/__w/1/jspecify/src/main/java/org/jspecify/nullness/NullUnmarked.java:44: error: unmappable character (0x99) for encoding US-ASCII
 * <p>Otherwise it is considered null-unmarked: whether that???s because it is more narrowly enclosed
````

I can only reproduce the issue in the CI system, not locally.

This PR explicitly sets the javadoc encoding to UTF-8, which fixes the issue, see the corresponding EISOP PR:
https://github.com/eisop/checker-framework/pull/323

Alternatively, we could replace the offending character in `jspecify/src/main/java/org/jspecify/nullness/NullUnmarked.java`.

Another alternative might be to change the CF docker images in some way, but I didn't see anything related to encodings in them.

Typetools [disabled their JSpecify dependency](https://github.com/typetools/checker-framework/commit/803bc76c71944cf53956771b669c570dc2ea3517), which I can't do in EISOP.

(Note that I didn't look at the Javadoc HTML output before or after this change, so I don't know whether anything changes.)