### PR TITLE
Run CI jobs on multiple JDK versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,15 +4,19 @@ on: [push, pull_request]
 
 jobs:
   build:
+    name: JDK ${{ matrix.java_version }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java_version: [11,17]
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 11 # to use compile-time analysis by Errorprone
-        uses: actions/setup-java@v2
+      - name: Set up JDK ${{ matrix.java_version }} # to use compile-time analysis by Errorprone
+        uses: actions/setup-java@v3
         with:
-          distribution: adopt
-          java-version: 11
+          distribution: temurin
+          java-version: ${{ matrix.java_version }}
           cache: gradle
       - run: |
           ./gradlew spotlessCheck build publishToMavenLocal --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java_version: [11,17]
+        java_version: [11, 17, 18, 19-ea]
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
I chose 11, 17, 18, and 19-ea, but this can easily be tweaked.

I also updated to `actions/setup-java@v3` and switched to the maintained Temurin JDK distribution.