### PR TITLE
Mark 19-ea as experimental.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         java_version: [11, 17, 18]
+        experimental: [false]
         include:
           - java_version: 19-ea
             experimental: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java_version: [11, 17, 18, 19-ea]
+        java_version: [11, 17, 18]
+        include:
+          - java_version: 19-ea
+            experimental: true
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
         include:
           - java_version: 19-ea
             experimental: true
+    continue-on-error: ${{ matrix.experimental }}
     steps:
       - uses: actions/checkout@v2
       - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
I'm hoping that this will address [a sporadic(?)
failure](https://github.com/cpovirk/jspecify/runs/7975247419):

```
Could not open settings generic class cache for settings file '/home/runner/work/jspecify/jspecify/settings.gradle' (/home/runner/.gradle/caches/7.5.1/scripts/8fxsx7a5az16qabak9o2v29h1).
> BUG! exception in phase 'semantic analysis' in source unit '_BuildScript_' Unsupported class file major version 63
```

Gradle doesn't clearly support Java 19 yet:
https://docs.gradle.org/current/userguide/compatibility.html

I'm basing this config on [similar configuration in Error
Prone](https://github.com/google/error-prone/blob/f94a04d407583bc9f85847089d72298deecf6fb0/.github/workflows/ci.yml#L23).