### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # JSpecify
 
-An artifact of well-specified annotations to power static analysis checks and JVM language interop.
-Developed by consensus of the partner organizations listed at our main web site, [jspecify.org](http://jspecify.org).
+**Note: This project is still under active development. Any and all aspects of
+the project are subject to change prior to the 1.0 release. Do not depend on it
+for production use.**
+
+An artifact of well-specified annotations to power static analysis checks and
+JVM language interop.  Developed by consensus of the partner organizations
+listed at our main web site, [jspecify.org](http://jspecify.org).
 
 Our current focus is on annotations for nullness analysis.
 
-The latest release is numbered 0.2 as a clear signal to **not** depend on it yet.
-It will still undergo many changes.
-
 ## How to build
 
-Run `./gradlew` to build artifacts, or `./gradlew publishToMavenLocal` to install artifacts to your Local Maven Repository.
+Run `./gradlew` to build artifacts, or `./gradlew publishToMavenLocal` to
+install artifacts to your Local Maven Repository.


### PR DESCRIPTION
Make the warning about changes pre-1.0 more prominent.

FWIW, this change isn't strictly necessary since we don't have anyone saying they *didn't* realize it was pre-1.0 and subject to change, however, I think it's important to make caveats like this hard to miss.