### PR TITLE
Replace leading `@` in code snippets in Javadoc

### DIFF
--- a/src/main/java/org/jspecify/meta/Implies.java
+++ b/src/main/java/org/jspecify/meta/Implies.java
@@ -36,13 +36,13 @@ import java.lang.annotation.Target;
  * public @interface One {}
  *
  * // Additional meaning of `@Two`, if any, specified here.
- * @Implies(One.class)
+ * &commat;Implies(One.class)
  * public @interface Two {}
  *
  * // These might be classes, fields, methods, etc.
- * @One declaration_a
- * @Two declaration_b
- * @One @Two declaration_c
+ * &commat;One declaration_a
+ * &commat;Two declaration_b
+ * &commat;One @Two declaration_c
  * }</pre>
  *
  * <p>In this example, the meaning conveyed by the annotations is exactly the same for {@code

--- a/src/main/java/org/jspecify/nullness/Nullable.java
+++ b/src/main/java/org/jspecify/nullness/Nullable.java
@@ -29,9 +29,9 @@ import java.lang.annotation.Target;
  * <p>Example usages:
  *
  * <pre>{@code
- * @Nullable String field;
+ * &commat;Nullable String field;
  *
- * @Nullable String getField() { return field; }
+ * &commat;Nullable String getField() { return field; }
  *
  * void setField(@Nullable String value) { field = value; }
  *


### PR DESCRIPTION
Use `&commat;` so that the Javadoc processor doesn't try to interpret them as block tags.