### PR TITLE
Don't create Javadoc before Java 15.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,3 @@ jobs:
           cache: gradle
       - run: |
           ./gradlew spotlessCheck build publishToMavenLocal --no-daemon
-        if: matrix.java_version != '11'  
-      - run: |
-          ./gradlew spotlessCheck build publishToMavenLocal -x javadoc --no-daemon
-        if: matrix.java_version == '11'  

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,9 @@ dependencies {
 }
 
 java {
-    withJavadocJar()
+    if (JavaVersion.current() > JavaVersion.VERSION_14) {
+        withJavadocJar()
+    }
     withSourcesJar()
 
     sourceCompatibility 8


### PR DESCRIPTION
(#293)

Earlier versions can't handle leading `@` in example code.

(cherry picked from commit e182ccd1b745071139da255bcf2a09a0b7fe300e)