### PR TITLE
revise about page

### DIFF
--- a/docs/src/pages/about.md
+++ b/docs/src/pages/about.md
@@ -31,7 +31,7 @@ at enabling automated refactorings and bug prevention.
 Many of their most beneficial analyses require certain Java annotations (such as `@Nullable` or
 `@Immutable`) to be present in the source or class file being analyzed. Yet for the 
 going-on-two-decades since Java annotations were introduced, there's been no serious and 
-successful effort to provide a single well-specified standard for these annotations with 
+successful effort to provide a single well-specified artifact for these annotations with 
 industry consensus. Instead, each tool has generally provided its own, and each tool interprets 
 the meanings of the annotations differently.
 

--- a/docs/src/pages/about.md
+++ b/docs/src/pages/about.md
@@ -1,42 +1,10 @@
 ---
-title: About
+title: About Us
 ---
 
-# JSpecify
+## Who are we?
 
-**Tool-independent Annotations for Java Static Analysis**
-
-## Our Goal
-
-Java static analysis tools, such as Error Prone and those built into IDEs, have been very successful at enabling automated refactorings and bug prevention.
-Many of their most beneficial analyses require certain Java annotations (such as ``@Nullable`` or ``@Immutable``) to be present in the source or class file.
-
-Yet for the 15 years since Java annotations were introduced (five years for type-use annotations), users have never had a clear answer for which incarnation of these annotation classes they can safely adopt.
-Many such artifacts have been created, but there has never been a serious and successful effort to provide a single well-specified standard with industry consensus.
-
-The lack of this artifact has constrained the prevalence and overall value of static analysis technology throughout the industry.
-It has encouraged today's tools to accept a wide variety of annotations, treating them equivalently, which renders the annotation specifications meaningless (an API owner cannot know whether applying a particular annotation is correct without knowing which tool its users will be using to interpret them).
-
-Finally, it complicates interoperation between Java and other JVM languages, which sometimes expect additional API metadata (such as nullability) that the Java language can't express.
-
-This missing artifact, with full specifications, is what we are working to create.
-
-:::caution xkcd
-We have seen the xkcd comic. Please do not send us the xkcd comic. We know about the xkcd comic.
-:::
-
-## Activity
-
-The primary location for our day-to-day work is on GitHub: https://github.com/jspecify/jspecify
-
-## Talks about JSpecify
-
-* [JVMLS19 overview presentation](https://drive.google.com/file/d/15wZ-cVPkfsNYzSez9WrAF4gEjWNzlDAD/view>)
-
-## Participants
-
-People from the following projects and organizations are collaborating on this project:
-
+The following projects and organizations are collaborating on this project:
 
 | Project                                                 | Organization                                  |
 |---------------------------------------------------------|-----------------------------------------------|
@@ -55,8 +23,28 @@ People from the following projects and organizations are collaborating on this p
 | [SpotBugs](http://spotbugs.rtfd.io/)                    | [SpotBugs Team](https://github.com/spotbugs/) |
 | (various)                                               | [Square](https://squareup.com)                |
 
+## What are we trying to do?
+
+Java static analysis tools, such as Error Prone and those built into IDEs, have been very successful
+at enabling automated refactorings and bug prevention.
+
+Many of their most beneficial analyses require certain Java annotations (such as `@Nullable` or
+`@Immutable`) to be present in the source or class file. Yet for the going-on-two-decades since 
+Java annotations were introduced, there's been no serious and successful effort to provide a single
+well-specified standard for these annotations with industry consensus. Instead, each tool has
+generally provided its own, and each tool interprets the meanings of the annotations differently.
+
+We think the lack of such an artifact has been one of the factors constraining the prevalance and 
+overall value of static analysis technology throughout the industry. And it complicates 
+interoperation between Java and other JVM languages, which sometimes expect additional API 
+metadata (such as for nullness) that the Java language can't express.
+
+So, here we are. That's what we're working on.
+
+:::caution xkcd
+We have seen the xkcd comic. Please do not send us the xkcd comic. We know about the xkcd comic.
+:::
 
 ## Contact Info
 
 Email the group at <jspecify-dev@googlegroups.com>.
-

--- a/docs/src/pages/about.md
+++ b/docs/src/pages/about.md
@@ -29,10 +29,11 @@ Java static analysis tools, such as Error Prone and those built into IDEs, have 
 at enabling automated refactorings and bug prevention.
 
 Many of their most beneficial analyses require certain Java annotations (such as `@Nullable` or
-`@Immutable`) to be present in the source or class file. Yet for the going-on-two-decades since 
-Java annotations were introduced, there's been no serious and successful effort to provide a single
-well-specified standard for these annotations with industry consensus. Instead, each tool has
-generally provided its own, and each tool interprets the meanings of the annotations differently.
+`@Immutable`) to be present in the source or class file being analyzed. Yet for the 
+going-on-two-decades since Java annotations were introduced, there's been no serious and 
+successful effort to provide a single well-specified standard for these annotations with 
+industry consensus. Instead, each tool has generally provided its own, and each tool interprets 
+the meanings of the annotations differently.
 
 We think the lack of such an artifact has been one of the factors constraining the prevalance and 
 overall value of static analysis technology throughout the industry. And it complicates 


### PR DESCRIPTION
Tried to turn the "about page" into more specifically an "about us" page. In the process I didn't quite feel like nuking the "what are we trying to do" text. It does seem like it belongs somewhere else, but I didn't want to try to solve that problem yet.