### PR TITLE
Switch back to Standard (from Tool-Independent) in titles

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'JSpecify',
-  tagline: 'Tool-Independent Annotations for Java Static Analysis',
+  tagline: 'Standard Annotations for Java Static Analysis',
   url: 'http://jspecify.org/',
   baseUrl: '/',
   onBrokenLinks: 'throw',

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -35,7 +35,7 @@ export default function Home() {
   return (
     <Layout
       title={`${siteConfig.title} Main`}
-      description="Tool-Independent Annotations for Java Static Analysis">
+      description="Standard Annotations for Java Static Analysis">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
I'm still using tool-independent in a couple places where it seems like it wants to be more descriptive.