### PR TITLE
Update Sonar references in 'about' page

### DIFF
--- a/docs/src/pages/about.md
+++ b/docs/src/pages/about.md
@@ -14,7 +14,7 @@ Our current members are
 | [Meta](https://about.facebook.com)            | [Infer](https://www.fbinfer.com)             |
 | [Oracle](https://www.oracle.com)              | [OpenJDK](https://openjdk.java.net)          |
 | [PMD Team](https://pmd.github.io/)            | [PMD](https://pmd.github.io/)                |
-| [SonarSource](https://www.sonarsource.com/)   | [SonarQube](https://www.sonarqube.org/)      |
+| [Sonar](https://www.sonarsource.com/)         | [SonarQube](https://www.sonarqube.org/), [SonarCloud](https://www.sonarcloud.io/), [SonarLint](http://www.sonarlint.com/) |
 | [SpotBugs Team](https://github.com/spotbugs/) | [SpotBugs](http://spotbugs.rtfd.io/)         |
 | [Square](https://squareup.com)                | (various)                                    |
 | [Uber](https://uber.com)                      | [NullAway](https://github.com/uber/NullAway) |


### PR DESCRIPTION
* The company public name changed from SonarSource to Sonar in 2022
* Add distinct links for the 3 tools