### PR TITLE
Add a sample inspired by `NullsFirstOrdering` and `NullsLastOrdering.`

### DIFF
--- a/samples/ExtendsTypeVariableImplementedForNullableTypeArgument.java
+++ b/samples/ExtendsTypeVariableImplementedForNullableTypeArgument.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.jspecify.annotations.NullnessUnspecified;
+
+@NullMarked
+class ExtendsTypeVariableImplementedForNullableTypeArgument {
+  interface NullableBounded<T extends @Nullable Object> {
+    <U extends T> void x(U u);
+
+    interface Sub0 extends NullableBounded<@Nullable Object> {
+      // jspecify_nullness_mismatch
+      <U> void x(U u);
+    }
+
+    interface Sub1 extends NullableBounded<@Nullable Object> {
+      // jspecify_nullness_mismatch
+      <U extends Object> void x(U u);
+    }
+
+    interface Sub2 extends NullableBounded<@Nullable Object> {
+      // jspecify_nullness_not_enough_information
+      <U extends @NullnessUnspecified Object> void x(U u);
+    }
+
+    interface Sub3 extends NullableBounded<@Nullable Object> {
+      <U extends @Nullable Object> void x(U u);
+    }
+  }
+}


### PR DESCRIPTION
We had them declared wrong in Guava until
https://github.com/google/guava/pull/6251. We got away with it because
the current reference checker doesn't issue an error.

I would expect an error from declaring _any_ override whose
type-parameter declarations don't match its supermethod's. (That's what
you get from javac if attempt similar mischief with base types.
Presumably it's failing the return-type-substitutability check in JLS
8.4.5 when it finds that it can't "adapt to the type parameters" of the
original method, since it doesn't meet the "same type parameters" laid
out in 8.4.4?

I notice that the Checker Framework won't issue an error merely for the
type-parameter mismatch. However, it _will_ issue an error if you then
declare method parameters (and probably certain kinds of return types),
so it probably does catch any problem that could lead to an actual
runtime error. And maybe they'd even consider their more lenient
approach a feature, a generalization of [contravariant
parameters](https://github.com/jspecify/jspecify/issues/49)? I'd need to
think more about that, but I'm hoping not to bother.

In any case, it doesn't surprise me too much that our checker would miss
this error: We're inheriting the Checker Framework's leniency for the
type-parameter declaration, and then we've edited our code for checking
overrides (likely including parameters and/or return types), possibly
making it more lenient in the process. I wonder if there's anything I
would have done differently in that code if I'd realized that the
Checker Framework was being lenient about the declarations?
Realistically, probably nothing: I was confused throughout the work
discussed in https://github.com/jspecify/checker-framework/issues/10.