### PR TITLE
Add JDK19 (non-Early Access) as a non-experimental CI job.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java_version: [11, 17, 18]
+        java_version: [11, 17, 18, 19]
         experimental: [false]
-        include:
-          - java_version: 19-ea
-            experimental: true
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We expect that this works after
https://github.com/jspecify/jspecify/pull/358

It does appear that the 19-ea job has passed since then. That said, the
error was flaky, not a consistent failure, and thus the most recent
dozen-plus runs _before_ that PR had passed, too. Still, let's try this
and see how it goes.

This will hopefully wrap up our work on
https://github.com/jspecify/jspecify/issues/320.