### PR TITLE
Fix "Draft Javadoc" link.

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -94,7 +94,7 @@ const config = {
               },
               {
                 label: 'Draft Javadoc',
-                href: '/docs/api/org/jspecify/annotations/package-summary.html',
+                href: 'http://jspecify.org/docs/api/org/jspecify/annotations/package-summary.html',
               },
               {
                 label: 'Draft Specification',


### PR DESCRIPTION
Compare https://github.com/jspecify/jspecify/pull/324.

I notice that this makes the link open in a new tab by default, too, as
presumably is the default for "external" pages. That's not necessarily
ideal, but it's tolerable, and it's way better than a broken link :)
