### PR TITLE
docs: fail builds on invalid markdown links; update action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,7 @@ jobs:
 
   # Deploys the documentation if this is a push to the main branch.
   deploy:
+    name: Deploy Documentation
     if: github.event_name == 'push' && github.ref == 'refs/head/main'
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,25 +4,37 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    branches:
+      - main
     paths:
       - 'docs/**'
 
 jobs:
+  # Runs on PRs and push to ensure the documentation successfully builds.
   build:
+    name: Build Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: actions/setup-node@v3
         with:
           node-version: 18
 
-      - run: npm install
+      - name: Install Dependencies
+        run: npm install
         working-directory: docs
 
-      - run: npm run build
+      - name: Build Documentation
+        run: npm run build
         working-directory: docs
 
+  # Deploys the documentation if this is a push to the main branch.
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/head/main'
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/upload-artifact@v2
         with:
           name: document
@@ -32,4 +44,3 @@ jobs:
         with:
           branch: gh-pages
           folder: docs/build
-        if: github.event_name == 'push'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'docs/**'
 
 jobs:
   # Runs on PRs and push to ensure the documentation successfully builds.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
   url: 'http://jspecify.org/',
   baseUrl: '/',
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenMarkdownLinks: 'throw',
   favicon: 'img/jspecify-favicon.ico',
 
   // GitHub pages deployment config.


### PR DESCRIPTION
This commit updates our docusaurus config to throw an error on invalid markdown links. I'm not certain that it will do much at all to help catch issues like #346, but it will at least make our builds stricter in general. We can disable this if it become to onerous.

This also refactors our Docs github workflow slightly to make it more modular. We check builds on PRs to main and build and deploy only on a push to main.