### PR TITLE
Update gradle-nexus.publish-plugin to 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java-library'
-    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0' apply false
+    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0' apply false
     id 'com.diffplug.spotless' version '6.14.0'
     id 'net.ltgt.errorprone' version '3.0.1'
 }


### PR DESCRIPTION
This avoids a deprecation warning when using Gradle 8.0.