### PR TITLE
Add samples for `@NonNull`.

### DIFF
--- a/samples/NonNullProjection.java
+++ b/samples/NonNullProjection.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+class NonNullProjection<T extends @Nullable Object> {
+  Object parametric(T t) {
+    // jspecify_nullness_mismatch
+    return t;
+  }
+
+  Object projected(@NonNull T t) {
+    return t;
+  }
+}

--- a/samples/NonNullSimple.java
+++ b/samples/NonNullSimple.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+class NonNullSimple {
+  @NonNull
+  Object passthrough(@Nullable Object o) {
+    // jspecify_nullness_mismatch
+    return o;
+  }
+}


### PR DESCRIPTION
The reference checker already supports these, but I've been keeping [the
relevant feature
request](https://github.com/jspecify/nullness-checker-for-checker-framework/issues/17)
open until we have proper tests.
