### PR TITLE
Use `test:cannot-convert` in place of `jspecify_nullness_mismatch` in a few places.

### DIFF
--- a/samples/packageDefault/packagedefault/Bar.java
+++ b/samples/packageDefault/packagedefault/Bar.java
@@ -20,7 +20,7 @@ import org.jspecify.annotations.Nullable;
 
 class Bar {
   Object x(@Nullable Object o) {
-    // jspecify_nullness_mismatch
+    // test:cannot-convert:Object? to Object!
     return o;
   }
 }

--- a/samples/selfType/selftype/SelfType.java
+++ b/samples/selfType/selftype/SelfType.java
@@ -58,21 +58,21 @@ abstract class Super extends C<@Nullable CK> {
 abstract class CKN extends Super {
   public void main() {
     ak().foo(ak());
-    // test:cannot-convert:null to AK!
+    // test:cannot-convert:null? to AK!
     ak().foo(null);
 
-    // test:cannot-convert:null to AK!
+    // test:cannot-convert:null? to AK!
     akn().foo(null);
 
     bk().foo(bk());
-    // test:cannot-convert:null to B!
+    // test:cannot-convert:null? to B!
     bk().foo(null);
 
     ck().foo(ck());
-    // test:cannot-convert:null to CK!
+    // test:cannot-convert:null? to CK!
     ck().foo(null);
 
-    // test:cannot-convert:null to CK!
+    // test:cannot-convert:null? to CK!
     ckn().foo(null);
   }
 }

--- a/samples/selfType/selftype/SelfType.java
+++ b/samples/selfType/selftype/SelfType.java
@@ -33,7 +33,7 @@ class C<E extends C<E>> extends SelfType<E> {}
 // jspecify_nullness_not_enough_information
 class AK extends SelfType<AK> {}
 
-// jspecify_nullness_mismatch
+// test:cannot-convert:AK? to SelfType!<AK!>
 class AKN extends SelfType<@Nullable AK> {}
 
 class BK extends B {}
@@ -42,7 +42,7 @@ class BK extends B {}
 class CK extends C<CK> {}
 
 @NullMarked
-// jspecify_nullness_mismatch
+// test:cannot-convert:CK? to C!<CK!>
 abstract class Super extends C<@Nullable CK> {
   abstract AK ak();
 
@@ -58,21 +58,21 @@ abstract class Super extends C<@Nullable CK> {
 abstract class CKN extends Super {
   public void main() {
     ak().foo(ak());
-    // jspecify_nullness_mismatch
+    // test:cannot-convert:null to AK!
     ak().foo(null);
 
-    // jspecify_nullness_mismatch
+    // test:cannot-convert:null to AK!
     akn().foo(null);
 
     bk().foo(bk());
-    // jspecify_nullness_mismatch
+    // test:cannot-convert:null to B!
     bk().foo(null);
 
     ck().foo(ck());
-    // jspecify_nullness_mismatch
+    // test:cannot-convert:null to CK!
     ck().foo(null);
 
-    // jspecify_nullness_mismatch
+    // test:cannot-convert:null to CK!
     ckn().foo(null);
   }
 }


### PR DESCRIPTION
Don't merge until https://github.com/jspecify/nullness-checker-for-checker-framework/pull/68 is merged and a new PR is created just for the report updates.