### PR TITLE
Update spotless version, format annotations, and apply to all .java files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0' apply false
-    id 'com.diffplug.spotless' version '6.14.0'
+    id 'com.diffplug.spotless' version '6.18.0'
     id 'net.ltgt.errorprone' version '3.0.1'
 }
 

--- a/cftojspecify/java/com/google/devtools/javatools/typeannotationrefactoring/CheckerFrameworkToJspecifyRefactoring.java
+++ b/cftojspecify/java/com/google/devtools/javatools/typeannotationrefactoring/CheckerFrameworkToJspecifyRefactoring.java
@@ -1,17 +1,18 @@
-// Copyright 2020 The JSpecify Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
+/*
+ * Copyright 2020 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.devtools.javatools.typeannotationrefactoring;
 
 import static com.google.common.base.Verify.verify;
@@ -405,7 +406,7 @@ public final class CheckerFrameworkToJspecifyRefactoring {
     ParserFactory parserFactory = ParserFactory.instance(context);
     JavacParser parser =
         parserFactory.newParser(
-            input, /*keepDocComments=*/ true, /*keepEndPos=*/ true, /*keepLineMap=*/ true);
+            input, /* keepDocComments= */ true, /* keepEndPos= */ true, /* keepLineMap= */ true);
     JCCompilationUnit unit = parser.parseCompilationUnit();
     unit.sourcefile = source;
     if (diagnostics.getDiagnostics().stream().anyMatch(d -> d.getKind() == ERROR)) {

--- a/conformance/Basic.java
+++ b/conformance/Basic.java
@@ -13,15 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package conformance;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 class Basic {
-  @NonNull
-  Object cannotConvertNullableToNonNull(@Nullable Object nullable) {
+  @NonNull Object cannotConvertNullableToNonNull(@Nullable Object nullable) {
     // test:cannot-convert:Object? to Object!
     return nullable;
   }

--- a/gradle/format.gradle
+++ b/gradle/format.gradle
@@ -1,8 +1,11 @@
 spotless {
     java {
+        target '**/*.java'
+        targetExclude 'gradle/license-header.java'
         removeUnusedImports()
         googleJavaFormat()
         licenseHeaderFile "gradle/license-header.java"
+        formatAnnotations().addTypeAnnotation('NullnessUnspecified')
     }
     groovyGradle {
         target '**/*.gradle'

--- a/samples/AnnotatedInnerOfNonParameterized.java
+++ b/samples/AnnotatedInnerOfNonParameterized.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/AnnotatedInnerOfParameterized.java
+++ b/samples/AnnotatedInnerOfParameterized.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/AnnotatedReceiver.java
+++ b/samples/AnnotatedReceiver.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/AnnotatedTypeParameter.java
+++ b/samples/AnnotatedTypeParameter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/AnnotatedTypeParameterUnspec.java
+++ b/samples/AnnotatedTypeParameterUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/AnnotatedWildcard.java
+++ b/samples/AnnotatedWildcard.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/AnnotatedWildcardUnspec.java
+++ b/samples/AnnotatedWildcardUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ArraySameType.java
+++ b/samples/ArraySameType.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ArraySubtype.java
+++ b/samples/ArraySubtype.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/AssignmentAsExpression.java
+++ b/samples/AssignmentAsExpression.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/AugmentedInferenceAgreesWithBaseInference.java
+++ b/samples/AugmentedInferenceAgreesWithBaseInference.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/BoundedTypeVariableReturn.java
+++ b/samples/BoundedTypeVariableReturn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/CaptureAsInferredTypeArgument.java
+++ b/samples/CaptureAsInferredTypeArgument.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConversionForSubtyping.java
+++ b/samples/CaptureConversionForSubtyping.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/CaptureConvertedToObject.java
+++ b/samples/CaptureConvertedToObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedToObjectUnionNull.java
+++ b/samples/CaptureConvertedToObjectUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedToObjectUnspec.java
+++ b/samples/CaptureConvertedToObjectUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedToOther.java
+++ b/samples/CaptureConvertedToOther.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedToOtherUnionNull.java
+++ b/samples/CaptureConvertedToOtherUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedToOtherUnspec.java
+++ b/samples/CaptureConvertedToOtherUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnionNullToObject.java
+++ b/samples/CaptureConvertedUnionNullToObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnionNullToObjectUnionNull.java
+++ b/samples/CaptureConvertedUnionNullToObjectUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnionNullToObjectUnspec.java
+++ b/samples/CaptureConvertedUnionNullToObjectUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnionNullToOther.java
+++ b/samples/CaptureConvertedUnionNullToOther.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnionNullToOtherUnionNull.java
+++ b/samples/CaptureConvertedUnionNullToOtherUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnionNullToOtherUnspec.java
+++ b/samples/CaptureConvertedUnionNullToOtherUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnspecToObject.java
+++ b/samples/CaptureConvertedUnspecToObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnspecToObjectUnionNull.java
+++ b/samples/CaptureConvertedUnspecToObjectUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnspecToObjectUnspec.java
+++ b/samples/CaptureConvertedUnspecToObjectUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnspecToOther.java
+++ b/samples/CaptureConvertedUnspecToOther.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnspecToOtherUnionNull.java
+++ b/samples/CaptureConvertedUnspecToOtherUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CaptureConvertedUnspecToOtherUnspec.java
+++ b/samples/CaptureConvertedUnspecToOtherUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CastOfCaptureOfNotNullMarkedUnboundedWildcardForObjectBoundedTypeParameter.java
+++ b/samples/CastOfCaptureOfNotNullMarkedUnboundedWildcardForObjectBoundedTypeParameter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 
 class CastOfCaptureOfNotNullMarkedUnboundedWildcardForObjectBoundedTypeParameter {

--- a/samples/CastOfCaptureOfUnboundedWildcardForNotNullMarkedObjectBoundedTypeParameter.java
+++ b/samples/CastOfCaptureOfUnboundedWildcardForNotNullMarkedObjectBoundedTypeParameter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 
 class CastOfCaptureOfUnboundedWildcardForNotNullMarkedObjectBoundedTypeParameter {

--- a/samples/CastOfCaptureOfUnboundedWildcardForObjectBoundedTypeParameter.java
+++ b/samples/CastOfCaptureOfUnboundedWildcardForObjectBoundedTypeParameter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked

--- a/samples/CastToPrimitive.java
+++ b/samples/CastToPrimitive.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/CastWildcardToTypeVariable.java
+++ b/samples/CastWildcardToTypeVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/Catch.java
+++ b/samples/Catch.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked

--- a/samples/ClassLiteral.java
+++ b/samples/ClassLiteral.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked

--- a/samples/ClassToObject.java
+++ b/samples/ClassToObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ClassToSelf.java
+++ b/samples/ClassToSelf.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ComplexParametric.java
+++ b/samples/ComplexParametric.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ConcatResult.java
+++ b/samples/ConcatResult.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ConflictingAnnotations.java
+++ b/samples/ConflictingAnnotations.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/Constants.java
+++ b/samples/Constants.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 
 class Constants {

--- a/samples/ContainmentExtends.java
+++ b/samples/ContainmentExtends.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ContainmentExtendsBounded.java
+++ b/samples/ContainmentExtendsBounded.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/ContainmentSuper.java
+++ b/samples/ContainmentSuper.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ContainmentSuperVsExtends.java
+++ b/samples/ContainmentSuperVsExtends.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ContainmentSuperVsExtendsSameType.java
+++ b/samples/ContainmentSuperVsExtendsSameType.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/ContravariantReturns.java
+++ b/samples/ContravariantReturns.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/CovariantReturns.java
+++ b/samples/CovariantReturns.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/DereferenceClass.java
+++ b/samples/DereferenceClass.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/DereferenceIntersection.java
+++ b/samples/DereferenceIntersection.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/DereferenceTernary.java
+++ b/samples/DereferenceTernary.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/DereferenceTypeVariable.java
+++ b/samples/DereferenceTypeVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/EnumAnnotations.java
+++ b/samples/EnumAnnotations.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ExtendsSameType.java
+++ b/samples/ExtendsSameType.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ExtendsTypeVariableImplementedForNullableTypeArgument.java
+++ b/samples/ExtendsTypeVariableImplementedForNullableTypeArgument.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ExtendsVsExtendsNullable.java
+++ b/samples/ExtendsVsExtendsNullable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/IfCondition.java
+++ b/samples/IfCondition.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/InferenceChoosesNullableTypeVariable.java
+++ b/samples/InferenceChoosesNullableTypeVariable.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/InstanceOfCheck.java
+++ b/samples/InstanceOfCheck.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/IntersectionSupertype.java
+++ b/samples/IntersectionSupertype.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/LocalVariable.java
+++ b/samples/LocalVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableToObject.java
+++ b/samples/MultiBoundTypeVariableToObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableToObjectUnionNull.java
+++ b/samples/MultiBoundTypeVariableToObjectUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableToObjectUnspec.java
+++ b/samples/MultiBoundTypeVariableToObjectUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableToOther.java
+++ b/samples/MultiBoundTypeVariableToOther.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableToOtherUnionNull.java
+++ b/samples/MultiBoundTypeVariableToOtherUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableToOtherUnspec.java
+++ b/samples/MultiBoundTypeVariableToOtherUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableToSelf.java
+++ b/samples/MultiBoundTypeVariableToSelf.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableToSelfUnionNull.java
+++ b/samples/MultiBoundTypeVariableToSelfUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableToSelfUnspec.java
+++ b/samples/MultiBoundTypeVariableToSelfUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnionNullToObject.java
+++ b/samples/MultiBoundTypeVariableUnionNullToObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnionNullToObjectUnionNull.java
+++ b/samples/MultiBoundTypeVariableUnionNullToObjectUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnionNullToObjectUnspec.java
+++ b/samples/MultiBoundTypeVariableUnionNullToObjectUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnionNullToOther.java
+++ b/samples/MultiBoundTypeVariableUnionNullToOther.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnionNullToOtherUnionNull.java
+++ b/samples/MultiBoundTypeVariableUnionNullToOtherUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnionNullToOtherUnspec.java
+++ b/samples/MultiBoundTypeVariableUnionNullToOtherUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnionNullToSelf.java
+++ b/samples/MultiBoundTypeVariableUnionNullToSelf.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnionNullToSelfUnionNull.java
+++ b/samples/MultiBoundTypeVariableUnionNullToSelfUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnionNullToSelfUnspec.java
+++ b/samples/MultiBoundTypeVariableUnionNullToSelfUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnspecToObject.java
+++ b/samples/MultiBoundTypeVariableUnspecToObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnspecToObjectUnionNull.java
+++ b/samples/MultiBoundTypeVariableUnspecToObjectUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnspecToObjectUnspec.java
+++ b/samples/MultiBoundTypeVariableUnspecToObjectUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnspecToOther.java
+++ b/samples/MultiBoundTypeVariableUnspecToOther.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnspecToOtherUnionNull.java
+++ b/samples/MultiBoundTypeVariableUnspecToOtherUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnspecToOtherUnspec.java
+++ b/samples/MultiBoundTypeVariableUnspecToOtherUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnspecToSelf.java
+++ b/samples/MultiBoundTypeVariableUnspecToSelf.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnspecToSelfUnionNull.java
+++ b/samples/MultiBoundTypeVariableUnspecToSelfUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiBoundTypeVariableUnspecToSelfUnspec.java
+++ b/samples/MultiBoundTypeVariableUnspecToSelfUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/MultiplePathsToTypeVariable.java
+++ b/samples/MultiplePathsToTypeVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NoPathToTypeVariableMinusNull.java
+++ b/samples/NoPathToTypeVariableMinusNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 
 class NoPathToTypeVariableMinusNull {

--- a/samples/NonConstantPrimitives.java
+++ b/samples/NonConstantPrimitives.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked

--- a/samples/NotNullMarkedAnnotatedInnerOfNonParameterized.java
+++ b/samples/NotNullMarkedAnnotatedInnerOfNonParameterized.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 
 abstract class NotNullMarkedAnnotatedInnerOfNonParameterized {

--- a/samples/NotNullMarkedAnnotatedInnerOfParameterized.java
+++ b/samples/NotNullMarkedAnnotatedInnerOfParameterized.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 
 abstract class NotNullMarkedAnnotatedInnerOfParameterized<T> {

--- a/samples/NotNullMarkedAnnotatedTypeParameter.java
+++ b/samples/NotNullMarkedAnnotatedTypeParameter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 
 class NotNullMarkedAnnotatedTypeParameter {

--- a/samples/NotNullMarkedAnnotatedTypeParameterUnspec.java
+++ b/samples/NotNullMarkedAnnotatedTypeParameterUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/NotNullMarkedAnnotatedWildcard.java
+++ b/samples/NotNullMarkedAnnotatedWildcard.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 
 class NotNullMarkedAnnotatedWildcard {

--- a/samples/NotNullMarkedAnnotatedWildcardUnspec.java
+++ b/samples/NotNullMarkedAnnotatedWildcardUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/NotNullMarkedClassToSelf.java
+++ b/samples/NotNullMarkedClassToSelf.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NotNullMarkedConcatResult.java
+++ b/samples/NotNullMarkedConcatResult.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/NotNullMarkedContainmentExtends.java
+++ b/samples/NotNullMarkedContainmentExtends.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/NotNullMarkedContainmentSuper.java
+++ b/samples/NotNullMarkedContainmentSuper.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/NotNullMarkedContainmentSuperVsExtends.java
+++ b/samples/NotNullMarkedContainmentSuperVsExtends.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/NotNullMarkedIfCondition.java
+++ b/samples/NotNullMarkedIfCondition.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/NotNullMarkedInferenceChoosesNullableTypeVariable.java
+++ b/samples/NotNullMarkedInferenceChoosesNullableTypeVariable.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 The JSpecify Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/NotNullMarkedLocalVariable.java
+++ b/samples/NotNullMarkedLocalVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NotNullMarkedOverrides.java
+++ b/samples/NotNullMarkedOverrides.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/NotNullMarkedTypeVariableBound.java
+++ b/samples/NotNullMarkedTypeVariableBound.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NotNullMarkedUnboxing.java
+++ b/samples/NotNullMarkedUnboxing.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NotNullMarkedUseOfTypeVariable.java
+++ b/samples/NotNullMarkedUseOfTypeVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NotNullMarkedUseOfTypeVariableAsTypeArgument.java
+++ b/samples/NotNullMarkedUseOfTypeVariableAsTypeArgument.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NotNullMarkedUseOfWildcardAsTypeArgument.java
+++ b/samples/NotNullMarkedUseOfWildcardAsTypeArgument.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NullCheck.java
+++ b/samples/NullCheck.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NullCheckTypeVariable.java
+++ b/samples/NullCheckTypeVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NullCheckTypeVariableUnionNullBound.java
+++ b/samples/NullCheckTypeVariableUnionNullBound.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NullCheckTypeVariableUnspecBound.java
+++ b/samples/NullCheckTypeVariableUnspecBound.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NullLiteralToClass.java
+++ b/samples/NullLiteralToClass.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NullLiteralToTypeVariable.java
+++ b/samples/NullLiteralToTypeVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NullLiteralToTypeVariableUnionNull.java
+++ b/samples/NullLiteralToTypeVariableUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NullLiteralToTypeVariableUnspec.java
+++ b/samples/NullLiteralToTypeVariableUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/NullMarkedDirectUseOfNotNullMarkedBoundedTypeVariable.java
+++ b/samples/NullMarkedDirectUseOfNotNullMarkedBoundedTypeVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/NullUnmarkedUndoesNullMarked.java
+++ b/samples/NullUnmarkedUndoesNullMarked.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
 

--- a/samples/NullUnmarkedUndoesNullMarkedForWildcards.java
+++ b/samples/NullUnmarkedUndoesNullMarkedForWildcards.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;

--- a/samples/NullnessDoesNotAffectOverloadSelection.java
+++ b/samples/NullnessDoesNotAffectOverloadSelection.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/ObjectAsSuperOfTypeVariable.java
+++ b/samples/ObjectAsSuperOfTypeVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/OutOfBoundsTypeVariable.java
+++ b/samples/OutOfBoundsTypeVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/OverrideParameters.java
+++ b/samples/OverrideParameters.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/OverrideParametersThatAreTypeVariables.java
+++ b/samples/OverrideParametersThatAreTypeVariables.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/OverrideReturns.java
+++ b/samples/OverrideReturns.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/ParameterizedWithTypeVariableArgumentToSelf.java
+++ b/samples/ParameterizedWithTypeVariableArgumentToSelf.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked

--- a/samples/PrimitiveAnnotations.java
+++ b/samples/PrimitiveAnnotations.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/PrimitiveAnnotationsUnspec.java
+++ b/samples/PrimitiveAnnotationsUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/SameTypeObject.java
+++ b/samples/SameTypeObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/SameTypeTypeVariable.java
+++ b/samples/SameTypeTypeVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/SuperNullableForNonNullableTypeParameter.java
+++ b/samples/SuperNullableForNonNullableTypeParameter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/SuperObject.java
+++ b/samples/SuperObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/SuperObjectUnionNull.java
+++ b/samples/SuperObjectUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/SuperObjectUnspec.java
+++ b/samples/SuperObjectUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/SuperSameType.java
+++ b/samples/SuperSameType.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/SuperTypeVariable.java
+++ b/samples/SuperTypeVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/SuperTypeVariableUnionNull.java
+++ b/samples/SuperTypeVariableUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/SuperTypeVariableUnspec.java
+++ b/samples/SuperTypeVariableUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/SuperVsObject.java
+++ b/samples/SuperVsObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/SuperVsSuperNullable.java
+++ b/samples/SuperVsSuperNullable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/Ternary.java
+++ b/samples/Ternary.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeArgumentOfTypeVariableBound.java
+++ b/samples/TypeArgumentOfTypeVariableBound.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeArgumentOfWildcardBound.java
+++ b/samples/TypeArgumentOfWildcardBound.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableMinusNullVsTypeVariable.java
+++ b/samples/TypeVariableMinusNullVsTypeVariable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/TypeVariableToObject.java
+++ b/samples/TypeVariableToObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableToObjectUnionNull.java
+++ b/samples/TypeVariableToObjectUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableToObjectUnspec.java
+++ b/samples/TypeVariableToObjectUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableToParent.java
+++ b/samples/TypeVariableToParent.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableToParentUnionNull.java
+++ b/samples/TypeVariableToParentUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableToParentUnspec.java
+++ b/samples/TypeVariableToParentUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableToSelf.java
+++ b/samples/TypeVariableToSelf.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableToSelfUnionNull.java
+++ b/samples/TypeVariableToSelfUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableToSelfUnspec.java
+++ b/samples/TypeVariableToSelfUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnionNullToObject.java
+++ b/samples/TypeVariableUnionNullToObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnionNullToObjectUnionNull.java
+++ b/samples/TypeVariableUnionNullToObjectUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnionNullToObjectUnspec.java
+++ b/samples/TypeVariableUnionNullToObjectUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnionNullToParent.java
+++ b/samples/TypeVariableUnionNullToParent.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnionNullToParentUnionNull.java
+++ b/samples/TypeVariableUnionNullToParentUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnionNullToParentUnspec.java
+++ b/samples/TypeVariableUnionNullToParentUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnionNullToSelf.java
+++ b/samples/TypeVariableUnionNullToSelf.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnionNullToSelfUnionNull.java
+++ b/samples/TypeVariableUnionNullToSelfUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnionNullToSelfUnspec.java
+++ b/samples/TypeVariableUnionNullToSelfUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnspecToObject.java
+++ b/samples/TypeVariableUnspecToObject.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnspecToObjectUnionNull.java
+++ b/samples/TypeVariableUnspecToObjectUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnspecToObjectUnspec.java
+++ b/samples/TypeVariableUnspecToObjectUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnspecToParent.java
+++ b/samples/TypeVariableUnspecToParent.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnspecToParentUnionNull.java
+++ b/samples/TypeVariableUnspecToParentUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnspecToParentUnspec.java
+++ b/samples/TypeVariableUnspecToParentUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnspecToSelf.java
+++ b/samples/TypeVariableUnspecToSelf.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnspecToSelfUnionNull.java
+++ b/samples/TypeVariableUnspecToSelfUnionNull.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/TypeVariableUnspecToSelfUnspec.java
+++ b/samples/TypeVariableUnspecToSelfUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;
@@ -111,8 +110,7 @@ class TypeVariableUnspecToSelfUnspec<
     return x;
   }
 
-  @NullnessUnspecified UnspecChildOfParametricT x14(
-      @NullnessUnspecified UnspecChildOfParametricT x) {
+  @NullnessUnspecified UnspecChildOfParametricT x14(@NullnessUnspecified UnspecChildOfParametricT x) {
     // jspecify_nullness_not_enough_information
     return x;
   }

--- a/samples/Unboxing.java
+++ b/samples/Unboxing.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/UninitializedField.java
+++ b/samples/UninitializedField.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/UnionTypeArgumentWithUseSite.java
+++ b/samples/UnionTypeArgumentWithUseSite.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/UnrecognizedLocationsMisc.java
+++ b/samples/UnrecognizedLocationsMisc.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/UnspecifiedClassTypeArgumentForNonNullableParameter.java
+++ b/samples/UnspecifiedClassTypeArgumentForNonNullableParameter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 
 class UnspecifiedClassTypeArgumentForNonNullableParameter {

--- a/samples/UnspecifiedTypeArgumentForNonNullableParameter.java
+++ b/samples/UnspecifiedTypeArgumentForNonNullableParameter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/UnspecifiedTypeArgumentForNonNullableParameterRepeatedSubstitution.java
+++ b/samples/UnspecifiedTypeArgumentForNonNullableParameterRepeatedSubstitution.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/UnspecifiedTypeArgumentForNonNullableParameterUseUnspec.java
+++ b/samples/UnspecifiedTypeArgumentForNonNullableParameterUseUnspec.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullnessUnspecified;
 

--- a/samples/UnspecifiedTypeVariableTypeArgumentForNonNullableParameter.java
+++ b/samples/UnspecifiedTypeVariableTypeArgumentForNonNullableParameter.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 
 class UnspecifiedTypeVariableTypeArgumentForNonNullableParameter {

--- a/samples/UseOfTypeVariableAsTypeArgument.java
+++ b/samples/UseOfTypeVariableAsTypeArgument.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/UseOfTypeVariableUnionNullAsTypeArgument.java
+++ b/samples/UseOfTypeVariableUnionNullAsTypeArgument.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/UseOfTypeVariableUnspecAsTypeArgument.java
+++ b/samples/UseOfTypeVariableUnspecAsTypeArgument.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/WildcardBoundWithAnnotations.java
+++ b/samples/WildcardBoundWithAnnotations.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.jspecify.annotations.NullnessUnspecified;

--- a/samples/WildcardCapturesToBoundOfTypeParameterNotToTypeVariableItself.java
+++ b/samples/WildcardCapturesToBoundOfTypeParameterNotToTypeVariableItself.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 

--- a/samples/annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java
+++ b/samples/annotatedBoundsOfWildcard/annotatedboundsofwildcard/AnnotatedBoundsOfWildcard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package annotatedboundsofwildcard;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/defaults/defaults/Defaults.java
+++ b/samples/defaults/defaults/Defaults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package defaults;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/fullyQualified/fullyqualified/sub/Annotation.java
+++ b/samples/fullyQualified/fullyqualified/sub/Annotation.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package fullyqualified.sub;
 
 public @interface Annotation {}

--- a/samples/fullyQualified/fullyqualified/sub/Caller.java
+++ b/samples/fullyQualified/fullyqualified/sub/Caller.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package fullyqualified.sub;
 
 class Caller {

--- a/samples/fullyQualified/fullyqualified/sub/Clazz.java
+++ b/samples/fullyQualified/fullyqualified/sub/Clazz.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package fullyqualified.sub;
 
 public class Clazz {}

--- a/samples/fullyQualified/fullyqualified/sub/Enumeration.java
+++ b/samples/fullyQualified/fullyqualified/sub/Enumeration.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package fullyqualified.sub;
 
 public enum Enumeration {}

--- a/samples/fullyQualified/fullyqualified/sub/Interface.java
+++ b/samples/fullyQualified/fullyqualified/sub/Interface.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package fullyqualified.sub;
 
 public interface Interface {}

--- a/samples/ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java
+++ b/samples/ignoreAnnotations/ignoreannotations/IgnoreAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package ignoreannotations;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/implementWithNullableTypeArgument/implementwithnullabletypeargument/MyFunction.java
+++ b/samples/implementWithNullableTypeArgument/implementwithnullabletypeargument/MyFunction.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package implementwithnullabletypeargument;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/implementWithNullableTypeArgument/implementwithnullabletypeargument/SuperFunction.java
+++ b/samples/implementWithNullableTypeArgument/implementwithnullabletypeargument/SuperFunction.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package implementwithnullabletypeargument;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/implementWithNullableTypeArgument/implementwithnullabletypeargument/User.java
+++ b/samples/implementWithNullableTypeArgument/implementwithnullabletypeargument/User.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package implementwithnullabletypeargument;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/memberSelectNonExpression/memberselectnonexpression/MemberSelectNonExpressions.java
+++ b/samples/memberSelectNonExpression/memberselectnonexpression/MemberSelectNonExpressions.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package memberselectnonexpression;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/nonPlatformTypeParameter/nonplatformtypeparameter/NonPlatformTypeParameter.java
+++ b/samples/nonPlatformTypeParameter/nonplatformtypeparameter/NonPlatformTypeParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nonplatformtypeparameter;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java
+++ b/samples/nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package nullnessunspecifiedtypeparameter;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/packageDefault/packagedefault/Bar.java
+++ b/samples/packageDefault/packagedefault/Bar.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package packagedefault;
 
 import org.jspecify.annotations.Nullable;

--- a/samples/selfType/selftype/SelfType.java
+++ b/samples/selfType/selftype/SelfType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package selftype;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/simple/simple/Simple.java
+++ b/samples/simple/simple/Simple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package simple;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/typeArgumentsFromParameterBounds/typeargumentsfromparameterbounds/TypeArgumentsFromParameterBounds.java
+++ b/samples/typeArgumentsFromParameterBounds/typeargumentsfromparameterbounds/TypeArgumentsFromParameterBounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package typeargumentsfromparameterbounds;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/typeParameterBounds/typeparameterbounds/TypeParameterBounds.java
+++ b/samples/typeParameterBounds/typeparameterbounds/TypeParameterBounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package typeparameterbounds;
 
 import org.jspecify.annotations.NullMarked;

--- a/samples/wildcardsWithDefault/wildcardswithdefault/WildcardsWithDefault.java
+++ b/samples/wildcardsWithDefault/wildcardswithdefault/WildcardsWithDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The jspecify Authors.
+ * Copyright 2020 The JSpecify Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package wildcardswithdefault;
 
 import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
When I saw [this comment](https://github.com/jspecify/jspecify/pull/378#discussion_r1178158343) I was wondering why spotless didn't do this automatically.

The first commit in this PR updates the configuration and the second commit adds the resulting changes.