### PR TITLE
Consistently use actions/checkout@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         experimental: [false]
     continue-on-error: ${{ matrix.experimental }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
       - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v3


### PR DESCRIPTION
I noticed the following warning in our GitHub Actions: `Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.`

The buildfile inconsistently use v2 and v3. This PR uses v3 consistently.