### PR TITLE
remove Kengo and SpotBugs team from the doc

### DIFF
--- a/docs/locale/ja/LC_MESSAGES/index.po
+++ b/docs/locale/ja/LC_MESSAGES/index.po
@@ -189,14 +189,6 @@ msgstr ""
 msgid "`SonarSource <https://www.sonarsource.com/>`_"
 msgstr ""
 
-#: ../../index.rst:60
-msgid "`SpotBugs <http://spotbugs.rtfd.io/>`_"
-msgstr ""
-
-#: ../../index.rst:60
-msgid "`SpotBugs Team <https://github.com/spotbugs/>`_"
-msgstr ""
-
 #: ../../index.rst:62
 msgid "`Square <https://squareup.com>`_"
 msgstr ""

--- a/docs/src/pages/about.md
+++ b/docs/src/pages/about.md
@@ -16,7 +16,6 @@ Our current members are
 | [Oracle](https://www.oracle.com)              | [OpenJDK](https://openjdk.java.net)          |
 | [PMD Team](https://pmd.github.io/)            | [PMD](https://pmd.github.io/)                |
 | [Sonar](https://www.sonarsource.com/)         | [SonarQube](https://www.sonarqube.org/), [SonarCloud](https://www.sonarcloud.io/), [SonarLint](http://www.sonarlint.com/) |
-| [SpotBugs Team](https://github.com/spotbugs/) | [SpotBugs](http://spotbugs.rtfd.io/)         |
 | [Square](https://squareup.com)                | (various)                                    |
 | [Uber](https://uber.com)                      | [NullAway](https://github.com/uber/NullAway) |
 | [VMware](https://www.vmware.com/)             | [Spring](https://tanzu.vmware.com/spring-app-framework) |

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -33,13 +33,6 @@ publishing {
                         name = 'Kevin Bourrillion'
                         email = 'kevinb@google.com'
                     }
-                    developer {
-                        id = 'KengoTODA'
-                        name = 'Kengo TODA'
-                        email = 'skypencil@gmail.com'
-                        url = 'https://github.com/KengoTODA/'
-                        timezone = '+8'
-                    }
                 }
             }
         }


### PR DESCRIPTION
Hello jspecify team,

Last year I've retired from development of the SpotBugs core.
And recently I have less opportunity to contribute this project, so I want to remove my name from the `developers` metadata in the POM.

Also, there is no other SpotBugs teammate working on this project, so please consider to remove the SpotBugs itself from the doc.