### PR TITLE
Don't fail the CI if the conformance tests or samples tests fail.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,13 +52,15 @@ jobs:
           java-version: 17
       - name: Run Conformance Tests
         if: github.base_ref == 'main' # only PRs onto main
+        continue-on-error: true
         uses: gradle/gradle-build-action@v2
         with:
           arguments: conformanceTest conformanceTestOnSamples
           build-root-directory: ${{ vars.reference_checker_repo }}
       - name: Run Samples Tests
-        # PRs or pushes onto samples-google-prototype
-        if: github.base_ref == 'samples-google-prototype' || github.ref_name == 'samples-google-prototype'
+        # only PRs onto samples-google-prototype
+        if: github.base_ref == 'samples-google-prototype'
+        continue-on-error: true
         uses: gradle/gradle-build-action@v2
         with:
           arguments: jspecifySamplesTest


### PR DESCRIPTION
If we make changes to the test inputs, that might cause the reference checker to fail, and later be fixed, but it shouldn't prevent merging the PR onto this repo.

Also, only run `jspecifySamplesTest` test on PRs, not merges.