### PR TITLE
workflow: fix head ref identifier

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
   # Deploys the documentation if this is a push to the main branch.
   deploy:
     name: Deploy Documentation
-    if: github.event_name == 'push' && github.ref == 'refs/head/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It's refs/heads/main, not refs/head/main.

Attempt to fix the continuous deployment issue raised in https://github.com/jspecify/jspecify/issues/411#issuecomment-1688377040