### PR TITLE
workflow: fix build and deploy docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,11 @@ jobs:
         run: npm run build
         working-directory: docs
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: document
+          path: docs/build
+
   # Deploys the documentation if this is a push to the main branch.
   deploy:
     name: Deploy Documentation
@@ -34,10 +39,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/upload-artifact@v2
-        with:
+       - uses: actions/download-artifact@v2
+         with:
           name: document
-          path: docs/build
 
       - uses: JamesIves/github-pages-deploy-action@4.1.5
         with:


### PR DESCRIPTION
Use upload/download artifact to share built doc results across jobs.

Each job runs in a separate image, so the deploy job wasn't able to use build results. Following https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts, we use the artifact rules to persist the build output across the two jobs. This consumes some storage quota, but since we were already (incorrectly?) using upload artifact, I stuck with it.