### PR TITLE
workflow: specify an intermediate path when downloading built docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: document
+          path: docs/build
 
       - uses: JamesIves/github-pages-deploy-action@4.1.5
         with:


### PR DESCRIPTION
https://www.youtube.com/watch?v=6UX9Q46mNFQ

https://github.com/actions/download-artifact#compatibility-between-v1-and-v2v3