### PR TITLE
Change to install `java-library` and `distribution` plugins instead of `java-library-distribution` so that there's only one distribution.

### DIFF
--- a/conformance-tests/build.gradle
+++ b/conformance-tests/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'java-library-distribution'
+    id 'java-library'
+    id 'distribution'
 }
 
 group 'org.jspecify.conformance'
@@ -30,8 +31,7 @@ java {
 }
 
 distributions {
-    conformanceTests {
-        distributionBaseName = 'conformance-tests'
+    main {
         contents {
             into('/assertions') {
                 from sourceSets.assertions.java


### PR DESCRIPTION
Fixes #436.