### PR TITLE
Put the samples files into the conformance tests zip.

### DIFF
--- a/conformance-tests/build.gradle
+++ b/conformance-tests/build.gradle
@@ -40,6 +40,9 @@ distributions {
                 from depsJar
                 from configurations.assertionsRuntimeClasspath
             }
+            into('/samples') {
+                from '../samples'
+            }
         }
     }
 }


### PR DESCRIPTION
This helps to decouple the builds. To be used in https://github.com/jspecify/jspecify-reference-checker/pull/123.