### PR TITLE
Add missing link to issue 260

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -975,6 +975,7 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 [#181]: https://github.com/jspecify/jspecify/issues/181
 [#19]: https://github.com/jspecify/jspecify/issues/19
 [#1]: https://github.com/jspecify/jspecify/issues/1
+[#260]: https://github.com/jspecify/jspecify/issues/260
 [#28]: https://github.com/jspecify/jspecify/issues/28
 [#31]: https://github.com/jspecify/jspecify/issues/31
 [#33]: https://github.com/jspecify/jspecify/issues/33


### PR DESCRIPTION
The Markdown link section missed the link to issue 260. This PR fixes it.

![grafik](https://github.com/jspecify/jspecify/assets/1366654/c79f53f4-4005-43eb-9b91-211fabfc87e8)
