### PR TITLE
Publish conformance tests to depending projects

### DIFF
--- a/conformance-tests/build.gradle
+++ b/conformance-tests/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.jspecify.conformance'
-version '0.1.0-SNAPSHOT'
+version '0.0.0-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -87,4 +87,19 @@ publishing {
             }
         }
     }
+}
+
+// For local builds to be able to depend on the conformance tests.
+configurations {
+    conformanceTestsZip {
+        canBeConsumed = true
+        canBeResolved = false
+        attributes {
+            attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, 'conformance-tests'))
+        }
+    }
+}
+
+artifacts {
+    conformanceTestsZip distZip
 }

--- a/conformance-tests/build.gradle
+++ b/conformance-tests/build.gradle
@@ -51,3 +51,36 @@ dependencies {
 
 // Make sure assertions compile.
 check.dependsOn(compileAssertionsJava)
+
+publishing {
+    publications {
+        conformanceTests(MavenPublication) {
+            pom {
+                groupId = 'org.jspecify.conformance'
+                artifactId = 'conformance-tests'
+                name = 'JSpecify Conformance Test Suite'
+                description = 'Assertions and dependencies representing a suite of conformance tests for JSpecify'
+                url = 'http://jspecify.org/'
+                artifact(tasks.named('distZip', Zip).map { it.archiveFile })
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git@github.com:jspecify/jspecify.git'
+                    developerConnection = 'scm:git:git@github.com:jspecify/jspecify.git'
+                    url = 'https://github.com/jspecify/jspecify/'
+                }
+                developers {
+                    developer {
+                        id = 'netdpb'
+                        name = 'David P. Baker'
+                        email = 'dpb@google.com'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/conformance-tests/build.gradle
+++ b/conformance-tests/build.gradle
@@ -61,7 +61,7 @@ publishing {
                 name = 'JSpecify Conformance Test Suite'
                 description = 'Assertions and dependencies representing a suite of conformance tests for JSpecify'
                 url = 'http://jspecify.org/'
-                artifact(tasks.named('distZip', Zip).map { it.archiveFile })
+                artifact(distZip)
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'

--- a/conformance-tests/build.gradle
+++ b/conformance-tests/build.gradle
@@ -61,7 +61,7 @@ publishing {
                 name = 'JSpecify Conformance Test Suite'
                 description = 'Assertions and dependencies representing a suite of conformance tests for JSpecify'
                 url = 'http://jspecify.org/'
-                artifact(distZip)
+                artifact distZip
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'

--- a/conformance-tests/build.gradle
+++ b/conformance-tests/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.jspecify.conformance'
-version '0.0.0-SNAPSHOT'
+version '0.1.0-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -61,6 +61,7 @@ publishing {
             pom {
                 groupId = 'org.jspecify.conformance'
                 artifactId = 'conformance-tests'
+                version = project.version
                 name = 'JSpecify Conformance Test Suite'
                 description = 'Assertions and dependencies representing a suite of conformance tests for JSpecify'
                 url = 'http://jspecify.org/'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -36,36 +36,6 @@ publishing {
                 }
             }
         }
-        conformanceTests(MavenPublication) {
-            pom {
-                groupId = 'org.jspecify.conformance'
-                artifactId = 'conformance-tests'
-                version = '0.1.0-SNAPSHOT'
-                name = 'JSpecify Conformance Test Suite'
-                description = 'Assertions and dependencies representing a suite of conformance tests for JSpecify'
-                url = 'http://jspecify.org/'
-                artifact('conformance-tests/build/distributions/conformance-tests-0.0.0-SNAPSHOT.zip')
-                        .builtBy(tasks.getByPath(':conformance-tests:conformanceTestsDistZip'))
-                licenses {
-                    license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git@github.com:jspecify/jspecify.git'
-                    developerConnection = 'scm:git:git@github.com:jspecify/jspecify.git'
-                    url = 'https://github.com/jspecify/jspecify/'
-                }
-                developers {
-                    developer {
-                        id = 'netdpb'
-                        name = 'David P. Baker'
-                        email = 'dpb@google.com'
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -40,6 +40,7 @@ publishing {
             pom {
                 groupId = 'org.jspecify.conformance'
                 artifactId = 'conformance-tests'
+                version = '0.1.0-SNAPSHOT'
                 name = 'JSpecify Conformance Test Suite'
                 description = 'Assertions and dependencies representing a suite of conformance tests for JSpecify'
                 url = 'http://jspecify.org/'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -40,10 +40,11 @@ publishing {
             pom {
                 groupId = 'org.jspecify.conformance'
                 artifactId = 'conformance-tests'
-                name = 'JSpecify conformance tests'
-                description = 'Assertions and depdendencies representing a set of conformance tests for JSpecify'
+                name = 'JSpecify Conformance Test Suite'
+                description = 'Assertions and dependencies representing a suite of conformance tests for JSpecify'
                 url = 'http://jspecify.org/'
-                artifact('conformance-tests/build/distributions/conformance-tests-0.0.0-SNAPSHOT.zip').builtBy(tasks.getByPath(':conformance-tests:conformanceTestsDistZip'))
+                artifact('conformance-tests/build/distributions/conformance-tests-0.0.0-SNAPSHOT.zip')
+                        .builtBy(tasks.getByPath(':conformance-tests:conformanceTestsDistZip'))
                 licenses {
                     license {
                         name = 'The Apache License, Version 2.0'

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -70,8 +70,9 @@ publishing {
 nexusPublishing {
     repositories {
         sonatype {
-            // //only for users registered in Sonatype after 24 Feb 2021
+            // For users registered in Sonatype after 24 Feb 2021
             nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
+            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
         }
     }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -36,6 +36,34 @@ publishing {
                 }
             }
         }
+        conformanceTests(MavenPublication) {
+            pom {
+                groupId = 'org.jspecify.conformance'
+                artifactId = 'conformance-tests'
+                name = 'JSpecify conformance tests'
+                description = 'Assertions and depdendencies representing a set of conformance tests for JSpecify'
+                url = 'http://jspecify.org/'
+                artifact('conformance-tests/build/distributions/conformance-tests-0.0.0-SNAPSHOT.zip').builtBy(tasks.getByPath(':conformance-tests:conformanceTestsDistZip'))
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git@github.com:jspecify/jspecify.git'
+                    developerConnection = 'scm:git:git@github.com:jspecify/jspecify.git'
+                    url = 'https://github.com/jspecify/jspecify/'
+                }
+                developers {
+                    developer {
+                        id = 'netdpb'
+                        name = 'David P. Baker'
+                        email = 'dpb@google.com'
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -56,7 +84,7 @@ signing {
     sign publishing.publications.mavenJava
 }
 
-tasks.withType(Sign) {
+tasks.withType(Sign).configureEach {
     onlyIf {
         privateKey?.trim() && pgpPassword?.trim()
     }


### PR DESCRIPTION
Publish the snapshots, for now, to Sonatype. (Part of #299.)
Also make a consumable Gradle configuration for building locally.

https://github.com/jspecify/jspecify-reference-checker/pull/126 will use this.