### PR TITLE
Configure dependabot behavior

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: "gradle"
+  directory: "/"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+
+- package-ecosystem: "npm"
+  directory: "/docs"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
Dependabot by default only seems to update the npm packages: https://github.com/jspecify/jspecify/pulls?q=is%3Apr+author%3Aapp%2Fdependabot+

Adding this configuration file hopefully updates also the gradle and github actions versions.