### PR TITLE
Use upload-artifact@v4 to match download-artifact@v4.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm run build
         working-directory: docs
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: document
           path: docs/build


### PR DESCRIPTION
Fixes a docs build break ([example](https://github.com/jspecify/jspecify/actions/runs/7805130551/job/21288658577)).