### PR TITLE
Change from `? super Object` to `? super Number` to avoid errors

### DIFF
--- a/samples/AnnotatedWildcard.java
+++ b/samples/AnnotatedWildcard.java
@@ -25,14 +25,14 @@ class AnnotatedWildcard {
       Lib<@Nullable ?> x1,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@Nullable ? extends Object> x2,
+      Lib<@Nullable ? extends Number> x2,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@Nullable ? super Object> x3,
+      Lib<@Nullable ? super Number> x3,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@Nullable ? extends @Nullable Object> x4,
+      Lib<@Nullable ? extends @Nullable Number> x4,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@Nullable ? super @Nullable Object> x5) {}
+      Lib<@Nullable ? super @Nullable Number> x5) {}
 }

--- a/samples/AnnotatedWildcardUnspec.java
+++ b/samples/AnnotatedWildcardUnspec.java
@@ -26,14 +26,14 @@ class AnnotatedWildcardUnspec {
       Lib<@NullnessUnspecified ?> x1,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@NullnessUnspecified ? extends Object> x2,
+      Lib<@NullnessUnspecified ? extends Number> x2,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@NullnessUnspecified ? super Object> x3,
+      Lib<@NullnessUnspecified ? super Number> x3,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@NullnessUnspecified ? extends @Nullable Object> x4,
+      Lib<@NullnessUnspecified ? extends @Nullable Number> x4,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@NullnessUnspecified ? super @Nullable Object> x5) {}
+      Lib<@NullnessUnspecified ? super @Nullable Number> x5) {}
 }

--- a/samples/ClassSuperVsUnbounded.java
+++ b/samples/ClassSuperVsUnbounded.java
@@ -18,7 +18,7 @@ import org.jspecify.annotations.NullMarked;
 // did not manage to reproduce the failure from Invokable.java at 3861...
 @NullMarked
 abstract class ClassSuperVsUnbounded<T, R> implements java.lang.reflect.Member {
-  abstract Class<? super Object> make0();
+  abstract Class<? super Number> make0();
 
   @Override
   public abstract Class<? super T> getDeclaringClass();

--- a/samples/ContainmentSuperVsExtendsSameType.java
+++ b/samples/ContainmentSuperVsExtendsSameType.java
@@ -20,7 +20,7 @@ import org.jspecify.annotations.Nullable;
 class ContainmentSuperVsExtendsSameType {
   void x() {
     // :: error: jspecify_nullness_mismatch jspecify_but_expect_nothing
-    new Check<Lib<? extends Object>, Lib<? super Object>>();
+    new Check<Lib<? extends Number>, Lib<? super Number>>();
   }
 
   interface Lib<T extends @Nullable Object> {}

--- a/samples/NotNullMarkedAnnotatedWildcard.java
+++ b/samples/NotNullMarkedAnnotatedWildcard.java
@@ -23,14 +23,14 @@ class NotNullMarkedAnnotatedWildcard {
       Lib<@Nullable ?> x1,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@Nullable ? extends Object> x2,
+      Lib<@Nullable ? extends Number> x2,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@Nullable ? super Object> x3,
+      Lib<@Nullable ? super Number> x3,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@Nullable ? extends @Nullable Object> x4,
+      Lib<@Nullable ? extends @Nullable Number> x4,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@Nullable ? super @Nullable Object> x5) {}
+      Lib<@Nullable ? super @Nullable Number> x5) {}
 }

--- a/samples/NotNullMarkedAnnotatedWildcardUnspec.java
+++ b/samples/NotNullMarkedAnnotatedWildcardUnspec.java
@@ -24,14 +24,14 @@ class NotNullMarkedAnnotatedWildcardUnspec {
       Lib<@NullnessUnspecified ?> x1,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@NullnessUnspecified ? extends Object> x2,
+      Lib<@NullnessUnspecified ? extends Number> x2,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@NullnessUnspecified ? super Object> x3,
+      Lib<@NullnessUnspecified ? super Number> x3,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@NullnessUnspecified ? extends @Nullable Object> x4,
+      Lib<@NullnessUnspecified ? extends @Nullable Number> x4,
 
       // :: error: jspecify_unrecognized_location
-      Lib<@NullnessUnspecified ? super @Nullable Object> x5) {}
+      Lib<@NullnessUnspecified ? super @Nullable Number> x5) {}
 }

--- a/samples/SuperObject.java
+++ b/samples/SuperObject.java
@@ -20,6 +20,11 @@ import org.jspecify.annotations.NullnessUnspecified;
 @NullMarked
 class SuperObject {
   void foo(
+      // Wildcards with `? super Object` must have the same upper and lower bound. Here, the upper
+      // bound is @Nullable, whereas the lower bound is @NonNull.
+      // As javac doesn't allow us to keep track of the separate annotations, there is an error
+      // here.
+      // :: error: jspecify_conflicting_annotations
       Lib<? super Object> lib,
       Object t,
       @NullnessUnspecified Object tUnspec,

--- a/samples/SuperObjectUnspec.java
+++ b/samples/SuperObjectUnspec.java
@@ -20,6 +20,8 @@ import org.jspecify.annotations.NullnessUnspecified;
 @NullMarked
 class SuperObjectUnspec {
   void foo(
+      // See comment in SuperObject.
+      // :: error: jspecify_conflicting_annotations
       Lib<? super @NullnessUnspecified Object> lib,
       Object t,
       @NullnessUnspecified Object tUnspec,


### PR DESCRIPTION
In the samples errors I see 14 occurrences (at least in https://github.com/jspecify/jspecify-reference-checker/pull/165) of this kind of error:

````
      /home/runner/work/jspecify-reference-checker/jspecify-reference-checker/jspecify-reference-checker/build/conformanceTests/samples/AnnotatedWildcard.java:31: (type.invalid.super.wildcard) bounds must have the same annotations.
          Lib<@Nullable ? super Object> x3,
              ^
      super bound  : Object?
      extends bound: Object
````

That is a correct error, but not the point of these test cases.
This changes most occurrences to `? super Number` and adds expected errors otherwise.