### PR TITLE
Remove `jspecify_but_expect_nothing` b/c EISOP produces an error

### DIFF
--- a/samples/CaptureConvertedTypeVariableBounded.java
+++ b/samples/CaptureConvertedTypeVariableBounded.java
@@ -98,7 +98,7 @@ class CaptureConvertedTypeVariableBounded {
     }
 
     Object x1(Inner<? extends @NullnessUnspecified Object> p) {
-      // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+      // :: error: jspecify_nullness_not_enough_information
       return p.get();
     }
 


### PR DESCRIPTION
EISOP produces an expected error:

````
      /home/runner/work/jspecify-reference-checker/jspecify-reference-checker/jspecify-reference-checker/build/conformanceTests/samples/CaptureConvertedTypeVariableBounded.java:102: (return.type.incompatible) incompatible types in return.
          return p.get();
                      ^
      type of expression: capture#454 of ? extends T
      method return type: Object
````