### PR TITLE
Capture of `Object*` is not compatible with `Object*`.

### DIFF
--- a/samples/CastOfCaptureOfUnboundedWildcardForNotNullMarkedObjectBoundedTypeParameter.java
+++ b/samples/CastOfCaptureOfUnboundedWildcardForNotNullMarkedObjectBoundedTypeParameter.java
@@ -23,6 +23,7 @@ class CastOfCaptureOfUnboundedWildcardForNotNullMarkedObjectBoundedTypeParameter
 
   @NullMarked
   abstract class Sub implements Super {
+    // jspecify_nullness_not_enough_information
     void x(Supplier<?> supplier) {
       if (supplier != null) {
         // jspecify_nullness_not_enough_information


### PR DESCRIPTION
https://github.com/jspecify/jspecify-reference-checker/pull/165#discussion_r1503356503

Using a wildcard that captures `Object*` is not compatible with an `Object*` bound.