### PR TITLE
Fix a couple problems with building under JDK 22:

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java_version: [11, 17, 18, 19]
+        java_version: [11, 17, 21]
         experimental: [false]
     continue-on-error: ${{ matrix.experimental }}
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 plugins {
     id 'java-library'
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0' apply false
-    id 'com.diffplug.spotless' version '6.18.0'
+    id 'com.diffplug.spotless' version '6.25.0'
     id 'net.ltgt.errorprone' version '3.0.1'
 }
 

--- a/src/integrationTest/java/org/jspecify/annotations/NullMarkedTest.java
+++ b/src/integrationTest/java/org/jspecify/annotations/NullMarkedTest.java
@@ -33,12 +33,12 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("@NullMarked")
 class NullMarkedTest {
-  boolean isJava8() {
+  static boolean isJava8() {
     String version = System.getProperty("java.version");
     return version.startsWith("1.8");
   }
 
-  Set<String> loadTargets() {
+  static Set<String> loadTargets() {
     return Arrays.stream(NullMarked.class.getAnnotation(Target.class).value())
         .map(ElementType::toString)
         .collect(Collectors.toSet());
@@ -46,14 +46,14 @@ class NullMarkedTest {
 
   @Nested
   @DisplayName("with Java 8")
-  class WithJava8 {
+  static class WithJava8 {
     @BeforeEach
     void assumeJava8() {
       assumeTrue(isJava8());
     }
 
     @Test
-    void basicReflectionDoesNotThrowException() {
+    void onlyBasicReflectionWorks() {
       Object unused = NullMarked.class.getMethods();
       /*
        * But reading the *annotations* on NullMarked would result in an exception: Those annotations
@@ -67,7 +67,7 @@ class NullMarkedTest {
 
   @Nested
   @DisplayName("with Java 9+")
-  class WithJava9OrLater {
+  static class WithJava9OrLater {
     @BeforeEach
     void assumeJava9OrLater() {
       assumeFalse(isJava8());


### PR DESCRIPTION
- Upgrade Spotless to upgrade google-java-format.
- Make nested test classes `static` so that we don't end up with
  [synthetic parameters that upset our JDK-8 integration
  test](https://bugs.openjdk.org/browse/JDK-8058322).
  (https://errorprone.info/bugpattern/ClassCanBeStatic!)

Thanks to cushon@ for the pointers.

While there, rename a test that I should have renamed as part of
https://github.com/jspecify/jspecify/pull/270.

And update our CI versions to include JDK 21. (I haven't added JDK 22,
as we've seen some potential signs of remaining flakiness there.)