### PR TITLE
Change OSGi BSN to org.jspecify.annotations or org.jspecify

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,4 +1,4 @@
-Bundle-SymbolicName: org.jspecify.jspecify
+Bundle-SymbolicName: org.jspecify.annotations
 Bundle-Name: JSpecify annotations
 Bundle-Vendor: The JSpecify Authors
 Bundle-Description: An artifact of well-specified annotations to power static analysis checks and JVM language interop.


### PR DESCRIPTION
This is a proposal based on discussion in https://github.com/jspecify/jspecify/pull/428#issuecomment-2231769425 

> I'm not convince of BSN org.jspecify.jspecify. The second jspecify is superfluous. Since Maven uses two parts to identify an artifact by groupId and artifactId OSGI uses a single identifier the BSN only.
> E.g. com.acme:acme-api -> com.acme.api or org.foo:foo -> org.foo as decribed in [Apache Felix Maven Bundle Plugin (BND) doc](https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html#_default_behavior)
> What's next with jspecify? Further annotations in the current bundle then org.jspecify.annotations is a good candidate. Or something like an uber jar for all kinds of things then org.jspecify is fine.

I liked the proposal by @bjmi `org.jspecify.annotations`

- It transports the intention of the bundle in its current state - which is about "annotations".


## But what about just org.jspecify ?

There is also the proposal to just use `org.jspecify`

- currently it seems that the module-info.java uses `org.jspecify` 

https://github.com/jspecify/jspecify/blob/5bf4ae46059cc4821879ecae10522b77dd16c59b/src/java9/java/module-info.java#L16

If this should be kept, then it also makes sense to use the same for the OSGi BSN / Bundle-SymbolicName

This PR should serve to decide which one to use.