### PR TITLE
Fix half-broken links.

### DIFF
--- a/docs/docs/start-here.md
+++ b/docs/docs/start-here.md
@@ -53,7 +53,7 @@ questions, which you can look for in the [Nullness Design FAQ]. If you like,
     JSpecify 0.2.0, not 1.0.0. We're working on updating it.
 *   Our [wiki] has about 20 informal, non-normative articles on various topics
 *   Open [issues]
-*   [Try it out](using)
+*   [Try it out](/docs/using)
 
 ### Reference implementation
 

--- a/docs/docs/tool-conformance.md
+++ b/docs/docs/tool-conformance.md
@@ -19,13 +19,13 @@ information that JSpecify adds to code without forcing us to make judgments
 about whether that information represents problems or how that information
 should be communicated to users.
 
-JSpecify's [specification](spec) consists of an augmented type system including
-subtyping rules, as well as a set of rules for determining the augmented type of
-a type usage based on the annotations surrounding that type usage. The
-specification uses terms like "UNION_NULL", "null-marked scope", "multiple
-worlds", and "nullness-subtype-establishing paths"; it mostly doesn't talk
-explicitly about what that means for examples of Java code. However, the point
-of the specification is to imply things about real Java code.
+JSpecify's [specification](/docs/spec) consists of an augmented type system
+including subtyping rules, as well as a set of rules for determining the
+augmented type of a type usage based on the annotations surrounding that type
+usage. The specification uses terms like "UNION_NULL", "null-marked scope",
+"multiple worlds", and "nullness-subtype-establishing paths"; it mostly doesn't
+talk explicitly about what that means for examples of Java code. However, the
+point of the specification is to imply things about real Java code.
 
 Here is an example of the problem: Let's say that, according to JSpecify, the
 method `a(...)`'s parameter has a non-nullable type and the method `b()` has a
@@ -80,7 +80,7 @@ The questions are as follows:
         `Optional!<String!>`
 
 1.  Does a given expression represent a dereference of a nullable expression in
-    [some or all worlds](spec#multiple-worlds), as derived from the
+    [some or all worlds](/docs/spec#multiple-worlds), as derived from the
     null-augmented type of its reference, based only on JSpecify annotations on
     those symbols or surrounding scopes?
 
@@ -92,8 +92,8 @@ The questions are as follows:
         `returnsUnspecified()` returns `null`)
 
 1.  Is a given expression or type argument not a
-    [nullness subtype](spec#nullness-subtyping) of its context in some or all
-    worlds, as derived from the null-augmented types of their referenced
+    [nullness subtype](/docs/spec#nullness-subtyping) of its context in some or
+    all worlds, as derived from the null-augmented types of their referenced
     symbols, based only on JSpecify annotations on those symbols or surrounding
     scopes?
 
@@ -157,4 +157,4 @@ all without affecting its conformance to JSpecify.
 [expression context]: https://docs.google.com/document/d/1nbTnJ0-HubLnQPKSjK5CDZyoe6Al64vdlkoJxaYX9XY/preview?resourcekey=0-ADjPZnp8LN3dRX_ptjlagw&tab=t.0#bookmark=kix.w6xfjhkftb9r
 [expression]: https://docs.google.com/document/d/1nbTnJ0-HubLnQPKSjK5CDZyoe6Al64vdlkoJxaYX9XY/preview?resourcekey=0-ADjPZnp8LN3dRX_ptjlagw&tab=t.0#bookmark=kix.2r97mw74ac6r
 [Map.get]: https://github.com/jspecify/jdk/blob/b7435cff373c527aad82a062c5605f6f9c1bb0de/src/java.base/share/classes/java/util/Map.java#L255
-[spec-locations]: spec#recognized-locations-for-declaration-annotations
+[spec-locations]: /docs/spec#recognized-locations-for-declaration-annotations

--- a/docs/docs/using.md
+++ b/docs/docs/using.md
@@ -68,13 +68,14 @@ maven_jar(
 ### If your code has no nullness annotations
 
 If your code doesn't use nullness annotations yet, there's no time like the
-present! We have a high-level [strategy](applying) we recommend.
+present! We have a high-level [strategy](/docs/applying) we recommend.
 
 ### If your code already uses JSR-305 annotations
 
 Before migrating from the JSR-305 annotations to JSpecify annotations, see if
 the caveats about [Kotlin][Kotlin-caveats] or
-[annotation processors](whether#annotation-processors) apply to your situation.
+[annotation processors](/docs/whether#annotation-processors) apply to your
+situation.
 
 Migrating from JSR-305 annotations primarily entails changing imports, updating
 annotation names and locations, and addressing build errors. JSpecify's
@@ -112,8 +113,8 @@ on the whole class, package, or module.
 
 `@NullMarked` is similar to JSR-305's [`@ParametersAreNonnullByDefault`] and
 custom [`@TypeQualifierDefault`] annotations. Still, `@NullMarked` differs from
-those, including in [its effect on generics](user-guide#generics), so you may
-need to take advantage of your new ability to annotate locations like type
+those, including in [its effect on generics](/docs/user-guide#generics), so you
+may need to take advantage of your new ability to annotate locations like type
 arguments (as in `Future<@Nullable Credentials>`). `@NullMarked` is likely to
 have an effect closer to what you want, but it may require additional work on
 your part.
@@ -162,5 +163,5 @@ use both the Checker Framework annotations (for annotations like
 [`implementation`]: https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph
 [`optional`]: https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html
 [`provided`]: https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#dependency-scope
-[Kotlin-caveats]: whether#kotlin
+[Kotlin-caveats]: /docs/whether#kotlin
 [type-use annotations]: https://www.oracle.com/technical-resources/articles/java/ma14-architect-annotations.html#:~:text=Applying%20Type%20Annotations

--- a/docs/docs/whether.md
+++ b/docs/docs/whether.md
@@ -4,9 +4,9 @@ sidebar_position: 3
 
 # Should you use JSpecify annotations in your Java code?
 
-With the release of JSpecify 1.0.0, we guarantee backwards compatibility: we will
-not rename the annotations or move them or make other changes that would cause
-your compilation to fail when you update.
+With the release of JSpecify 1.0.0, we guarantee backwards compatibility: we
+will not rename the annotations or move them or make other changes that would
+cause your compilation to fail when you update.
 
 However, there are other things to think about when deciding whether to start
 using JSpecify annotations in your code, including at least:
@@ -20,7 +20,7 @@ using JSpecify annotations in your code, including at least:
 ## If your Java code doesn’t use nullness annotations yet
 
 If your Java code doesn’t already use nullness annotations, we recommend that
-you [start using JSpecify annotations](using).
+you [start using JSpecify annotations](/docs/using).
 
 Even if you are not currently using a nullness analyzer, applying JSpecify
 annotations can still provide benefits.


### PR DESCRIPTION
These links _usually_ work. However, if you navigate from _an external
site_ to a URL like https://jspecify.dev/docs/using, then you'll end up
at https://jspecify.dev/docs/using/ (with a trailing slash). (Links
_within_ the site apparently get intercepted to load the content and
update the URL through the magic of JavaScript, thereby avoiding this
problem. Compare https://github.com/jspecify/jspecify/issues/411 and
friends.)

Anyway, once you're at https://jspecify.dev/docs/using/, links like
those in "see if the caveats about Kotlin or annotation processors apply
to your situation" are broken... sometimes. If you right-click and "Open
link in new tab," they work fine. (The browser sees a link to
https://jspecify.dev/docs/whether#kotlin, for example.) However, as soon
as you left-click one of them, you get a 404 because the JavaScript
kicks in and navigates you to
https://jspecify.dev/docs/using/whether#kotlin. Then (fun fact) if you
use your browser's Back button, then you'll find that not just one but
_both_ of the `whether` links in that sentence have changed to really
have their `href` set to the broken
https://jspecify.dev/docs/using/whether#... URL, so not even the
right-click approach will work anymore.

The fix for all this is to write our links in the style `/docs/whether`
instead of just `whether`. netdpb@ had already discovered this pattern,
but [the
lesson](https://github.com/jspecify/jspecify/pull/564#pullrequestreview-2180877440)
didn't stick for me, even after I initially published the release notes
with a broken link :)
