### PR TITLE
Add trailing slashes to URLs.

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -25,6 +25,7 @@ const config = {
   tagline: 'Standard Annotations for Java Static Analysis',
   url: 'http://jspecify.org/',
   baseUrl: '/',
+  trailingSlash: true,
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   favicon: 'img/jspecify-favicon.ico',


### PR DESCRIPTION
The resulting URLs look less clean, but they will be more consistent
and, more importantly, more reliable.

To recap:

- GitHub Pages adds a trailing slash if you navigate directly to a URL
  from an external source. See my discussion in
  https://github.com/jspecify/jspecify/pull/577, and see the table at
  https://github.com/slorber/trailing-slash-guide?tab=readme-ov-file#summary.
- Docusaurus currently does _not_ add a trailing slash during intra-site
  navigation. This leads to inconsistent results that depend on the
  source of the link. And that makes it easy for links to be broken in
  some cases but us not to notice—nor Docusaurus to report an error.
- This PR makes Docusaurus add a trailing slash. See
  https://docusaurus.io/docs/api/docusaurus-config#trailingSlash.
