### PR TITLE
Remove `jspecify_but_...` where incorrect behavior has been fixed.

### DIFF
--- a/samples/CaptureAsInferredTypeArgument.java
+++ b/samples/CaptureAsInferredTypeArgument.java
@@ -37,11 +37,11 @@ interface CaptureAsInferredTypeArgument {
   }
 
   default void unspecBounded(Lib<? extends @NullnessUnspecified Object> l) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     useImplicitlyObjectBounded(l);
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     useExplicitlyObjectBounded(l);
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     useUnspecBounded(l);
     useUnionNullBounded(l);
   }

--- a/samples/CaptureConvertedToObject.java
+++ b/samples/CaptureConvertedToObject.java
@@ -48,12 +48,12 @@ class CaptureConvertedToObject {
   }
 
   Object x7(UnspecBounded<? extends @NullnessUnspecified Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 
   Object x8(UnspecBounded<? extends @Nullable Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 
@@ -62,7 +62,7 @@ class CaptureConvertedToObject {
   }
 
   Object x10(NullableBounded<? extends @NullnessUnspecified Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 

--- a/samples/CaptureConvertedToObjectUnspec.java
+++ b/samples/CaptureConvertedToObjectUnspec.java
@@ -48,12 +48,12 @@ class CaptureConvertedToObjectUnspec {
   }
 
   @NullnessUnspecified Object x7(UnspecBounded<? extends @NullnessUnspecified Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 
   @NullnessUnspecified Object x8(UnspecBounded<? extends @Nullable Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 
@@ -62,7 +62,7 @@ class CaptureConvertedToObjectUnspec {
   }
 
   @NullnessUnspecified Object x10(NullableBounded<? extends @NullnessUnspecified Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 

--- a/samples/CaptureConvertedToOther.java
+++ b/samples/CaptureConvertedToOther.java
@@ -48,12 +48,12 @@ class CaptureConvertedToOther {
   }
 
   Lib x7(UnspecBounded<? extends @NullnessUnspecified Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 
   Lib x8(UnspecBounded<? extends @Nullable Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 
@@ -62,7 +62,7 @@ class CaptureConvertedToOther {
   }
 
   Lib x10(NullableBounded<? extends @NullnessUnspecified Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 

--- a/samples/CaptureConvertedToOtherUnspec.java
+++ b/samples/CaptureConvertedToOtherUnspec.java
@@ -48,12 +48,12 @@ class CaptureConvertedToOtherUnspec {
   }
 
   @NullnessUnspecified Lib x7(UnspecBounded<? extends @NullnessUnspecified Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 
   @NullnessUnspecified Lib x8(UnspecBounded<? extends @Nullable Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 
@@ -62,7 +62,7 @@ class CaptureConvertedToOtherUnspec {
   }
 
   @NullnessUnspecified Lib x10(NullableBounded<? extends @NullnessUnspecified Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     return x.get();
   }
 

--- a/samples/CaptureConvertedTypeVariableBounded.java
+++ b/samples/CaptureConvertedTypeVariableBounded.java
@@ -73,7 +73,7 @@ class CaptureConvertedTypeVariableBounded {
     }
 
     Object x1(Inner<? extends @NullnessUnspecified Object> p) {
-      // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+      // :: error: jspecify_nullness_not_enough_information 
       return p.get();
     }
 

--- a/samples/ContainmentExtends.java
+++ b/samples/ContainmentExtends.java
@@ -22,7 +22,7 @@ class ContainmentExtends {
   void x() {
     new Check<Lib<? extends Foo>, Lib<? extends Foo>>();
 
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     new Check<Lib<? extends Foo>, Lib<? extends @NullnessUnspecified Foo>>();
 
     // :: error: jspecify_nullness_mismatch
@@ -30,7 +30,7 @@ class ContainmentExtends {
 
     new Check<Lib<? extends @NullnessUnspecified Foo>, Lib<? extends Foo>>();
 
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     new Check<Lib<? extends @NullnessUnspecified Foo>, Lib<? extends @NullnessUnspecified Foo>>();
 
     // :: error: jspecify_nullness_not_enough_information

--- a/samples/DereferenceIntersection.java
+++ b/samples/DereferenceIntersection.java
@@ -55,13 +55,13 @@ class DereferenceIntersection {
   }
 
   void x7(UnspecBounded<? extends @NullnessUnspecified Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     synchronized (x.get()) {
     }
   }
 
   void x8(UnspecBounded<? extends @Nullable Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     synchronized (x.get()) {
     }
   }
@@ -72,7 +72,7 @@ class DereferenceIntersection {
   }
 
   void x10(NullableBounded<? extends @NullnessUnspecified Lib> x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     synchronized (x.get()) {
     }
   }

--- a/samples/NotNullMarkedContainmentExtends.java
+++ b/samples/NotNullMarkedContainmentExtends.java
@@ -18,19 +18,19 @@ import org.jspecify.annotations.NullnessUnspecified;
 
 class NotNullMarkedContainmentExtends {
   void x() {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     new Check<Lib<? extends Foo>, Lib<? extends Foo>>();
 
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     new Check<Lib<? extends Foo>, Lib<? extends @NullnessUnspecified Foo>>();
 
     // :: error: jspecify_nullness_not_enough_information
     new Check<Lib<? extends Foo>, Lib<? extends @Nullable Foo>>();
 
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     new Check<Lib<? extends @NullnessUnspecified Foo>, Lib<? extends Foo>>();
 
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_not_enough_information 
     new Check<Lib<? extends @NullnessUnspecified Foo>, Lib<? extends @NullnessUnspecified Foo>>();
 
     // :: error: jspecify_nullness_not_enough_information

--- a/samples/NotNullMarkedTypeVariableBound.java
+++ b/samples/NotNullMarkedTypeVariableBound.java
@@ -49,17 +49,17 @@ class NotNullMarkedTypeVariableBound {
   @NullMarked
   class Callers {
     Object x0(UnspecBounded1<?>.Nested x) {
-      // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+      // :: error: jspecify_nullness_not_enough_information 
       return x.get();
     }
 
     Object x0(UnspecBounded2<?>.Nested x) {
-      // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+      // :: error: jspecify_nullness_not_enough_information 
       return x.get();
     }
 
     Object x0(UnspecBounded3<?>.Nested x) {
-      // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+      // :: error: jspecify_nullness_not_enough_information 
       return x.get();
     }
 

--- a/samples/NotNullMarkedUseOfWildcardAsTypeArgument.java
+++ b/samples/NotNullMarkedUseOfWildcardAsTypeArgument.java
@@ -28,12 +28,12 @@ class NotNullMarkedUseOfWildcardAsTypeArgument {
   @NullMarked
   class Caller {
     @Nullable Lib<? extends Object> x0(Super s) {
-      // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+      // :: error: jspecify_nullness_not_enough_information 
       return s.get();
     }
 
     @Nullable Lib<? extends @NullnessUnspecified Object> x1(Super s) {
-      // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+      // :: error: jspecify_nullness_not_enough_information 
       return s.get();
     }
 

--- a/samples/UseOfTypeVariableAsTypeArgument.java
+++ b/samples/UseOfTypeVariableAsTypeArgument.java
@@ -65,7 +65,7 @@ class UseOfTypeVariableAsTypeArgument {
     }
 
     Lib<? extends Object> x7(Super<? extends @NullnessUnspecified Object> s) {
-      // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
+      // :: error: jspecify_nullness_not_enough_information 
       return s.get();
     }
 


### PR DESCRIPTION
This makes `NullSpecTest$Strict` go from having 180 unexpected
diagnostics to having 146.
