### PR TITLE
Perform dependency updates in weekly batches.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,28 +4,28 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
-	groups:
-		dependencies:
-			applies-to: version-updates
-			patterns:
-				- "*"
+  groups:
+    dependencies:
+      applies-to: version-updates
+      patterns:
+        - "*"
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "weekly"
-	groups:
-		dependencies:
-			applies-to: version-updates
-			patterns:
-				- "*"
+  groups:
+    dependencies:
+      applies-to: version-updates
+      patterns:
+        - "*"
 
 - package-ecosystem: "npm"
   directory: "/docs"
   schedule:
     interval: "weekly"
-	groups:
-		dependencies:
-			applies-to: version-updates
-			patterns:
-				- "*"
+  groups:
+    dependencies:
+      applies-to: version-updates
+      patterns:
+        - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,29 @@ updates:
 - package-ecosystem: "gradle"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
+	groups:
+		dependencies:
+			applies-to: version-updates
+			patterns:
+				- "*"
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: "weekly"
+	groups:
+		dependencies:
+			applies-to: version-updates
+			patterns:
+				- "*"
 
 - package-ecosystem: "npm"
   directory: "/docs"
   schedule:
-    interval: "daily"
+    interval: "weekly"
+	groups:
+		dependencies:
+			applies-to: version-updates
+			patterns:
+				- "*"


### PR DESCRIPTION
Compare https://github.com/google/truth/pull/1304

This would presumably have avoided the problem discussed in
https://github.com/jspecify/jspecify/pull/598.
