### PR TITLE
Introduce the concepts of "comfortable" and "worried."

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -592,7 +592,7 @@ nullness operator `t`* if either of the following conditions holds:
 
 -   `g` is `UNSPECIFIED`, *and* the check is required to hold in [all worlds].
 
-> "Worried" is the complementary piece to "[comfortable]" above.
+> "Worried" is the complementary attitude to "[comfortable]" above.
 >
 > Suppose that a tool wants to determine whether to allow an expression of a
 > given type to be dereferenced. To do so, it can ask whether it should be

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -570,12 +570,12 @@ target nullness operator `t`* if either of the following conditions holds:
     this check.
 
 > The purpose of "comfortable" is to let a checker determine whether it will
-> allow `null` to be assigned to a field of a given type by asking
-> whether the fields' nullness operator *might be*
-> `UNION_NULL`. The first bullet covers the simple case, in which the nullness
-> operator matches exactly. The second case treats
-> null-unmarked code optimistically; it's possible that a given unnanotated
-> type usage in that context "ought to be" annotated with `@Nullable`.
+> allow `null` to be assigned to a field of a given type by asking whether the
+> fields' nullness operator *might be* `UNION_NULL`. The first bullet covers the
+> simple case, in which the nullness operator matches exactly. The second case
+> treats null-unmarked code optimistically; it's possible that a given
+> unnanotated type usage in that context "ought to be" annotated with
+> `@Nullable`.
 
 ## Worried about a given nullness operator {#worried}
 
@@ -587,12 +587,12 @@ nullness operator `t`* if either of the following conditions holds:
 -   `g` is `UNSPECIFIED`, *and* we are performing the [all-worlds] version of
     this check.
 
-> "Worried" serves a similar purpose to
-> "[comfortable]" above, except to support strict checkers. For example, a value can be unsafe to
-> dereference if its type has nullness operator `UNION_NULL`, but a strict
-> checker might issue errors also for dereferences of values whose type has nullness
-> operator `UNSPECIFIED`; it would be "worried" that an `UNSPECIFIED` type
-> "ought to be" annotated with `@Nullable.`
+> "Worried" serves a similar purpose to "[comfortable]" above, except to support
+> strict checkers. For example, a value can be unsafe to dereference if its type
+> has nullness operator `UNION_NULL`, but a strict checker might issue errors
+> also for dereferences of values whose type has nullness operator
+> `UNSPECIFIED`; it would be "worried" that an `UNSPECIFIED` type "ought to be"
+> annotated with `@Nullable.`
 
 ## Same type
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -802,17 +802,19 @@ hold:
 > Thus, the rules here are restricted to type variables and intersection types,
 > whose supertypes may have nullness annotations.
 
-`T` has nullness-subtype-establishing direct-supertype edges to the following:
+`T` has nullness-subtype-establishing direct-supertype edges to the all
+following types, subject to the exception given below:
 
--   if `T` is an augmented [intersection type]: all of the intersection type's
-    elements, except those whose [nullness operator] there is reason to be
-    [worried] is `UNION_NULL`
+-   if `T` is an augmented [intersection type]: all the intersection type's
+    elements
 
--   if `T` is an augmented type variable: all of the corresponding type
-    parameter's upper bounds, except those whose nullness operator there is
-    reason to be worried is `UNION_NULL`
+-   if `T` is an augmented type variable: all the corresponding type parameter's
+    upper bounds
 
 -   otherwise: no nodes
+
+Exception: `T` does *not* have edges to any types whose [nullness operator]
+there is reason to be [worried] is `UNION_NULL`.
 
 ## Nullness-delegating subtyping rules for Java {#nullness-delegating-subtyping}
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -569,13 +569,13 @@ target nullness operator `t`* if either of the following conditions holds:
 -   `g` is `UNSPECIFIED`, *and* we are performing the [some-world] version of
     this check.
 
-> The purpose of this definition is that a checker may want to ask a question
-> like "Can I put `null` into a field of this type?" It would do so by asking
-> whether we are comfortable treating the fields' nullness operator like
+> The purpose of "comfortable" is to let a checker determine whether it will
+> allow `null` to be assigned to a field of a given type by asking
+> whether the fields' nullness operator *might be*
 > `UNION_NULL`. The first bullet covers the simple case, in which the nullness
-> operator matches exactly. The second case implements lenient treatment for
-> null-unmarked code: It's possible that any type usage in unannotated code
-> "ought to be" annotated with `@Nullable`.
+> operator matches exactly. The second case treats
+> null-unmarked code optimistically; it's possible that a given unnanotated
+> type usage in that context "ought to be" annotated with `@Nullable`.
 
 ## Worried about a given nullness operator {#worried}
 
@@ -587,11 +587,11 @@ nullness operator `t`* if either of the following conditions holds:
 -   `g` is `UNSPECIFIED`, *and* we are performing the [all-worlds] version of
     this check.
 
-> This definition serves a similar purpose to that of the definition of
-> "[comfortable]" above. For example, one reason that a value can be unsafe to
-> dereference is that its type has nullness operator `UNION_NULL`. A strict
-> checker could also wish to issue errors for dereferences if the nullness
-> operator is `UNSPECIFIED`: It would be "worried" that an `UNSPECIFIED` type
+> "Worried" serves a similar purpose to
+> "[comfortable]" above, except to support strict checkers. For example, a value can be unsafe to
+> dereference if its type has nullness operator `UNION_NULL`, but a strict
+> checker might issue errors also for dereferences of values whose type has nullness
+> operator `UNSPECIFIED`; it would be "worried" that an `UNSPECIFIED` type
 > "ought to be" annotated with `@Nullable.`
 
 ## Same type

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -803,12 +803,13 @@ hold:
 
 `T` has nullness-subtype-establishing direct-supertype edges to the following:
 
--   if `T` is an augmented [intersection type]: each of the intersection type's
-    elements whose [nullness operator] we are not [worried] is `UNION_NULL`
-
--   if `T` is an augmented type variable: each of the corresponding type
-    parameter's upper bounds whose nullness operator we are not worried is
+-   if `T` is an augmented [intersection type]: all of the intersection type's
+    elements, except those whose [nullness operator] we are [worried] is
     `UNION_NULL`
+
+-   if `T` is an augmented type variable: all of the corresponding type
+    parameter's upper bounds, except those whose nullness operator we are
+    worried is `UNION_NULL`
 
 -   otherwise: no nodes
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -569,13 +569,19 @@ target nullness operator `t`* if either of the following conditions holds:
 -   `g` is `UNSPECIFIED`, *and* we are performing the [some-world] version of
     this check.
 
-> The purpose of "comfortable" is to let a checker determine whether it will
-> allow `null` to be assigned to a field of a given type by asking whether the
-> fields' nullness operator *might be* `UNION_NULL`. The first bullet covers the
-> simple case, in which the nullness operator matches exactly. The second case
-> treats null-unmarked code optimistically; it's possible that a given
-> unnanotated type usage in that context "ought to be" annotated with
-> `@Nullable`.
+> The purpose of "comfortable" (and "[worried]") is to offer tools the option to
+> treat null-unmarked code either optimistically or pessimistically. Tool
+> authors make this choice by choosing how to handle "[multiple worlds]."
+>
+> Suppose that a tool wants to determine whether it will allow `null` to be
+> assigned to a field of a given type. To do so, it can ask whether it is
+> "comfortable" treating the field type's nullness operator like `UNION_NULL`.
+>
+> -   If the nullness operator *is* `UNION_NULL`, then the assignment should
+>     clearly be allowed.
+> -   If the nullness operator is `UNSPECIFIED`, then it's possible that the
+>     operator "ought to be" `UNION_NULL`. A lenient tool might allow the
+>     assignment anyway, while a strict tool might not.
 
 ## Worried about a given nullness operator {#worried}
 
@@ -587,12 +593,17 @@ nullness operator `t`* if either of the following conditions holds:
 -   `g` is `UNSPECIFIED`, *and* we are performing the [all-worlds] version of
     this check.
 
-> "Worried" serves a similar purpose to "[comfortable]" above, except to support
-> strict checkers. For example, a value can be unsafe to dereference if its type
-> has nullness operator `UNION_NULL`, but a strict checker might issue errors
-> also for dereferences of values whose type has nullness operator
-> `UNSPECIFIED`; it would be "worried" that an `UNSPECIFIED` type "ought to be"
-> annotated with `@Nullable.`
+> "Worried" is the complementary piece to "[comfortable]" above.
+>
+> Suppose that a tool wants to determine whether to allow an expression of a
+> given type to be dereferenced. To do so, it can ask whether it should be
+> "worried" that the type's nullness operator is `UNION_NULL`.
+>
+> -   If the nullness operator *is* `UNION_NULL`, then the dereference clearly
+>     should not be allowed.
+> -   If the nullness operator is `UNSPECIFIED`, then it's possible that the
+>     operator "ought to be" `UNION_NULL`. A lenient tool might allow the
+>     dereference anyway, while a strict tool might not.
 
 ## Same type
 
@@ -1036,6 +1047,7 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 [intersection type]: #intersection-types
 [intersection types]: #intersection-types
 [javadoc]: http://jspecify.org/docs/api/org/jspecify/annotations/package-summary.html
+[multiple worlds]: #multiple-worlds
 [null-exclusive under every parameterization]: #null-exclusive-under-every-parameterization
 [null-inclusive under every parameterization]: #null-inclusive-under-every-parameterization
 [null-marked scope]: #null-marked-scope

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -566,8 +566,7 @@ a target nullness operator `t`* if either of the following conditions holds:
 
 -   `g` is `t`.
 
--   `g` is `UNSPECIFIED`, *and* the check is required to hold only in
-    [some world].
+-   `g` is `UNSPECIFIED`, *and* this is the [some-world] version of the rule.
 
 > The purpose of "comfortable" (and "[worried]") is to offer tools the option to
 > treat null-unmarked code either optimistically or pessimistically. Tool
@@ -590,7 +589,7 @@ nullness operator `t`* if either of the following conditions holds:
 
 -   `g` is `t`.
 
--   `g` is `UNSPECIFIED`, *and* the check is required to hold in [all worlds].
+-   `g` is `UNSPECIFIED`, *and* this is the [all-worlds] version of the rule.
 
 > "Worried" is the complementary attitude to "[comfortable]" above.
 >

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -561,13 +561,13 @@ version of another rule.
 
 ## Comfortable with a given nullness operator {#comfortable}
 
-We say that we are *comfortable treating a given [nullness operator] `g` like a
-target nullness operator `t`* if either of the following conditions holds:
+There is *reason to be comfortable treating a given [nullness operator] `g` like
+a target nullness operator `t`* if either of the following conditions holds:
 
 -   `g` is `t`.
 
--   `g` is `UNSPECIFIED`, *and* we are performing the [some-world] version of
-    this check.
+-   `g` is `UNSPECIFIED`, *and* the check is required to hold only in
+    [some world].
 
 > The purpose of "comfortable" (and "[worried]") is to offer tools the option to
 > treat null-unmarked code either optimistically or pessimistically. Tool
@@ -585,13 +585,12 @@ target nullness operator `t`* if either of the following conditions holds:
 
 ## Worried about a given nullness operator {#worried}
 
-We say that we are *worried that a given [nullness operator] `g` is a target
+There is *reason to be worried that a given [nullness operator] `g` is a target
 nullness operator `t`* if either of the following conditions holds:
 
 -   `g` is `t`.
 
--   `g` is `UNSPECIFIED`, *and* we are performing the [all-worlds] version of
-    this check.
+-   `g` is `UNSPECIFIED`, *and* the check is required to hold in [all worlds].
 
 > "Worried" is the complementary piece to "[comfortable]" above.
 >
@@ -732,7 +731,8 @@ formally specify it yet.
 A type is null-inclusive under every parameterization if it meets any of the
 following conditions:
 
--   We are [comfortable] treating its [nullness operator] like `UNION_NULL`.
+-   There is reason to be [comfortable] treating its [nullness operator] like
+    `UNION_NULL`.
 
 -   It is an [intersection type] whose elements all are null-inclusive under
     every parameterization.
@@ -779,7 +779,8 @@ A type is null-exclusive under every parameterization if it has a
 `A` has a nullness-subtype-establishing path to `F` if both of the following
 hold:
 
--   We are not [worried] that the nullness operator of `A` is `UNION_NULL`.
+-   There is *not* reason to be [worried] that the nullness operator of `A` is
+    `UNION_NULL`.
 -   There is a path from `A` to `F` through
     [nullness-subtype-establishing direct-supertype edges].
 
@@ -804,12 +805,12 @@ hold:
 `T` has nullness-subtype-establishing direct-supertype edges to the following:
 
 -   if `T` is an augmented [intersection type]: all of the intersection type's
-    elements, except those whose [nullness operator] we are [worried] is
-    `UNION_NULL`
+    elements, except those whose [nullness operator] there is reason to be
+    [worried] is `UNION_NULL`
 
 -   if `T` is an augmented type variable: all of the corresponding type
-    parameter's upper bounds, except those whose nullness operator we are
-    worried is `UNION_NULL`
+    parameter's upper bounds, except those whose nullness operator there is
+    reason to be worried is `UNION_NULL`
 
 -   otherwise: no nodes
 
@@ -874,9 +875,9 @@ The Java rules are defined in [JLS 4.5.1]. We add to them as follows:
     > This is just a part of our universal rule to treat a bare `?` like `?
     > extends Object`.
 
--   The rule written specifically for `? extends Object` applies only if we are
-    [comfortable] treating the nullness operator of the `Object` bound as
-    `UNION_NULL`.
+-   The rule written specifically for `? extends Object` applies only if there
+    is reason to be [comfortable] treating the nullness operator of the `Object`
+    bound as `UNION_NULL`.
 
 -   When the JLS refers to the same type `T` on both sides of a rule, the rule
     applies if and only if this spec defines the 2 types to be the [same type].


### PR DESCRIPTION
These concepts let us:

- consolidate the differences between existing "all-worlds" and "some-world" versions of rules (and this PR does so)
- avoid introducing many more such differences when we begin treating `UNSPECIFIED` as "maybe `MINUS_NULL`" for  https://github.com/jspecify/jspecify/issues/248
- give relatively clear names to concepts that I have previously been tempted to give [unclear names to](https://github.com/jspecify/jspecify-reference-checker/blob/db89327f9fc984f3689f8a9c8df40817fe8d0790/src/main/java/com/google/jspecify/nullness/NullSpecAnnotatedTypeFactory.java#L611-L618)
