### PR TITLE
Stop running Error Prone.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,13 +19,11 @@ plugins {
     id 'com.diffplug.spotless' version '6.25.0'
     id 'com.github.node-gradle.node' version '7.0.2'
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0' apply false
-    id 'net.ltgt.errorprone' version '4.0.1'
     id "biz.aQute.bnd.builder" version "7.0.0"
 }
 
 ext {
     junitVersion = '5.9.3'
-    errorproneVersion = '2.30.0'
 }
 
 repositories { mavenCentral() }
@@ -37,10 +35,6 @@ apply from: "gradle/mrjar.gradle"
 apply from: "gradle/integration-test.gradle"
 apply from: "gradle/format.gradle"
 apply from: "gradle/publish.gradle"
-
-dependencies {
-    errorprone "com.google.errorprone:error_prone_core:${errorproneVersion}"
-}
 
 java {
     if (javaVersion.canCompileOrRun(15)) {

--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -39,7 +39,6 @@ dependencies {
     integrationTestImplementation "org.junit.jupiter:junit-jupiter-api:${junitVersion}"
     integrationTestRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitVersion}"
     integrationTestRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.7.0'
-    errorprone "com.google.errorprone:error_prone_core:${errorproneVersion}"
 }
 
 tasks.named('compileIntegrationTestJava', JavaCompile).configure {


### PR DESCRIPTION
Running it is good practice, but running it has also gotten more complex
now that Error Prone depends on JSpecify.

Luckily, there is only so much that we can mess up in the declarations
of the annotations (and only a little more than that once you include
the integration tests).

(Please don't think too hard about the fact that Error Prone is
currently producing legitimate InvalidBlockTag and
UnrecognisedJavadocTag warnings because we're using a JDK11 toolchain
for Javadoc at the moment....)

Fixes https://github.com/jspecify/jspecify-reference-checker/issues/202
