### PR TITLE
Remove warning about not reflecting 1.0.0 decisions.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -14,12 +14,6 @@ very advanced users might find it interesting. But it would make a very poor
 introduction for anyone else; instead see our **[Start Here](/docs/start-here) page**.
 :::
 
-:::note Status of this specification
-
-This document is current as of JSpecify **0.2.0**, but does not reflect several
-design changes between then and **1.0.0**.
-:::
-
 --------------------------------------------------------------------------------
 
 ### The word "nullable"


### PR DESCRIPTION
Not that we're done updating the spec for 1.0.0 decisions yet. But we
won't merge the `specification-1.0` branch into `main` until we are.
