### PR TITLE
Treat Kotlin code as null-unmarked.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -352,7 +352,7 @@ At each declaration, check the following rules in order:
     `@NullUnmarked`, the type usage is in a null-marked scope.
 -   If the declaration is annotated with `@NullUnmarked` and *not* with
     `@NullMarked`, the type usage is *not* in a null-marked scope.
--   If the declaration is annotated with `@kotlin.Metadata`, then the type
+-   If the declaration is a top-level class annotated with `@kotlin.Metadata`, then the type
     usage is *not* in a null-marked scope.
 
 > If a given declaration is annotated with both `@NullMarked` and

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -352,8 +352,8 @@ At each declaration, check the following rules in order:
     `@NullUnmarked`, the type usage is in a null-marked scope.
 -   If the declaration is annotated with `@NullUnmarked` and *not* with
     `@NullMarked`, the type usage is *not* in a null-marked scope.
--   If the declaration is a top-level class annotated with `@kotlin.Metadata`, then the type
-    usage is *not* in a null-marked scope.
+-   If the declaration is a top-level class annotated with `@kotlin.Metadata`,
+    then the type usage is *not* in a null-marked scope.
 
 > If a given declaration is annotated with both `@NullMarked` and
 > `@NullUnmarked`, these rules behave as if neither annotation is present.

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -346,12 +346,14 @@ innermost.
 > defining that there exists a series of enclosing declarations for any type
 > usage, not just for a declaration.
 
-At each declaration, check two rules:
+At each declaration, check the following rules in order:
 
 -   If the declaration is annotated with `@NullMarked` and *not* with
     `@NullUnmarked`, the type usage is in a null-marked scope.
 -   If the declaration is annotated with `@NullUnmarked` and *not* with
     `@NullMarked`, the type usage is *not* in a null-marked scope.
+-   If the declaration is annotated with `@kotlin.Metadata`, then the type
+    usage is *not* in a null-marked scope.
 
 > If a given declaration is annotated with both `@NullMarked` and
 > `@NullUnmarked`, these rules behave as if neither annotation is present.


### PR DESCRIPTION
This rule is written such that a Kotlin class _would_ still be treated
as null-marked _if_ it (or an enclosing class) were annotated with
`@NullMarked`. That enables a user to annotate it if desired, but more
importantly, it allows a future version of Kotlin to produce that
annotation automatically.

Fixes https://github.com/jspecify/jspecify/issues/611

~This rule is written such that a Kotlin class _would_ still be treated
as null-marked _if_ it were annotated with `@NullMarked`. That enables a
user to annotate it if desired, but more importantly, it allows a future
version of Kotlin to produce that annotation automatically.~

~Still, we are likely to want to revisit this rule, especially if Kotlin
begins generating `@NullMarked`. In particular, as [noted by
netdpb@](https://github.com/jspecify/jspecify/issues/611#issue-2489956831),
if a Kotlin class is nested inside a `@NullMarked` Kotlin class, then
the nested class should probably also be treated as null-marked. Under
this current rule, it probably isn't, since we would (IIUC) see a
`@kotlin.Metadata` annotation on the nested class before seeing the
`@NullMarked` annotation on the enclosing class.~

~We could try to do better, but this PR's approach has the virtue of
being very easy to implement.~

~(So this PR might not really "fix"
https://github.com/jspecify/jspecify/issues/611, but I propose that it's
good enough for spec-1.0.0 purposes. We could probably even release spec
1.0.0 without any PR like this if we really wanted.)~