### PR TITLE
Deem annotations in `instanceof` to be unrecognized, even in type arguments.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -247,7 +247,7 @@ However, the type-use annotation is unrecognized in any of the following cases:
 
 -   type arguments of a receiver parameter's type
 
--   any component of an `instanceof` expression
+-   any component of the type after the `instanceof` operator
 
     > We may revisit this rule in the future in light of
     > [Pattern Matching for instanceof][JEP 394].

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -268,11 +268,6 @@ All locations that are not explicitly listed as recognized are unrecognized.
 >     > For example, `@Nullable List<String> strings = ...` or `String @Nullable
 >     > [] strings = ...` have unrecognized annotations.
 >
-> -   root type in a cast of `instanceof` expression
->
->     > For example, `(@Nullable List<String>) foo` has an unrecognized
->     > annotation.
->
 > -   some additional intrinsically non-nullable locations:
 >
 >     -   supertype in a class declaration

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -247,6 +247,11 @@ However, the type-use annotation is unrecognized in any of the following cases:
 
 -   type arguments of a receiver parameter's type
 
+-   any component of an `instanceof` expression
+
+    > We may revisit this rule in the future in light of
+    > [Pattern Matching for instanceof][JEP 394].
+
 All locations that are not explicitly listed as recognized are unrecognized.
 
 > Other notable unrecognized annotations include:
@@ -1052,6 +1057,7 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 [#80]: https://github.com/jspecify/jspecify/issues/80
 [#87]: https://github.com/jspecify/jspecify/issues/87
 [3-valued logic]: https://en.wikipedia.org/wiki/Three-valued_logic
+[JEP 394]: https://openjdk.org/jeps/394
 [JLS 1.3]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-1.html#jls-1.3
 [JLS 4.10.4]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.10.4
 [JLS 4.10]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.10


### PR DESCRIPTION
This addresses https://github.com/jspecify/jspecify/issues/626 enough
for 1.0 purposes, but as I note in a non-normative comment in the spec,
we may want to revisit it in the future. I'll keep the bug open but
remove it from the spec-1.0 milestone.
