### PR TITLE
Deem "`equals(Object o)`" in a record class to always have a nullable parameter type.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -1041,7 +1041,7 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 ## Expected annotations on record classes' `equals` methods
 
 > Because of the special case [above](#augmented-type-of-usage) that makes
-> record classes' `equals` method parameter always nullable, we include this rule so that tools
+> parameters of record classes' `equals` methods always nullable, we include this rule so that tools
 > can produce expected errors in some cases when the parameter is not annotated
 > with `@Nullable`.
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -383,6 +383,14 @@ condition is met, skip the remaining conditions.
     > If the type usage is annotated with both `@Nullable` and `@NonNull`, these
     > rules behave as if neither annotation is present.
 
+-   If the type usage is the parameter of `equals(Object)` in a subclass of
+    `java.lang.Record`, then its nullness operator is `UNSPECIFIED`.
+
+    > This special case handles the fact that the Java compiler automatically
+    > generates an implementation of `equals` in `Record` but does not include a
+    > `@Nullable` annotation on its parameter, even when the class is
+    > `@NullMarked`.
+
 -   If the type usage appears in a [null-marked scope], its nullness operator is
     `NO_CHANGE`.
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -1038,7 +1038,7 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 
     > See ["Augmented null types."](#null-types)
 
-## Harmonizing annotations on special type usages {#harmoize-annotations}
+## Expected annotations on record `equals` methods
 
 > Because of the special case [above](#augmented-type-of-usage) that makes
 > record `equals` parameters always nullable, we include this rule so that tools

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -1041,9 +1041,9 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 ## Expected annotations on record classes' `equals` methods
 
 > Because of the special case [above](#augmented-type-of-usage) that makes
-> parameters of record classes' `equals` methods always nullable, we include this rule so that tools
-> can produce expected errors in some cases when the parameter is not annotated
-> with `@Nullable`.
+> parameters of record classes' `equals` methods always nullable, we include
+> this rule so that tools can produce expected errors in some cases when the
+> parameter is not annotated with `@Nullable`.
 
 If a type usage is the parameter of `equals(Object)` in a subclass of
 `java.lang.Record`, then:

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -1040,7 +1040,7 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 
 ## Harmonizing annotations on special type usages {#harmoize-annotations}
 
-> Because of a special case [above][#augmented-type-of-usage] that makes record
+> Because of a special case [above](#augmented-type-of-usage) that makes record
 > `equals` parameters nullable, there is a mismatch between what `public boolean
 > equals(Object o)` means in a record class and what it would otherwise mean. To
 > harmonize this, we anticipate that tools will sometimes still produce errors

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -1038,10 +1038,10 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 
     > See ["Augmented null types."](#null-types)
 
-## Expected annotations on record `equals` methods
+## Expected annotations on record classes' `equals` methods
 
 > Because of the special case [above](#augmented-type-of-usage) that makes
-> record `equals` parameters always nullable, we include this rule so that tools
+> record classes' `equals` method parameter always nullable, we include this rule so that tools
 > can produce expected errors in some cases when the parameter is not annotated
 > with `@Nullable`.
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -1040,9 +1040,10 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 
 ## Harmonizing annotations on special type usages {#harmoize-annotations}
 
-> Because of the special case [above](#augmented-type-of-usage) that makes record
-> `equals` parameters always nullable, we include this rule so that tools can produce
-> expected errors in some cases when the parameter is not annotated with `@Nullable`.
+> Because of the special case [above](#augmented-type-of-usage) that makes
+> record `equals` parameters always nullable, we include this rule so that tools
+> can produce expected errors in some cases when the parameter is not annotated
+> with `@Nullable`.
 
 If a type usage is the parameter of `equals(Object)` in a subclass of
 `java.lang.Record`, then:

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -1040,11 +1040,9 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 
 ## Harmonizing annotations on special type usages {#harmoize-annotations}
 
-> Because of a special case [above](#augmented-type-of-usage) that makes record
-> `equals` parameters nullable, there is a mismatch between what `public boolean
-> equals(Object o)` means in a record class and what it would otherwise mean. To
-> harmonize this, we anticipate that tools will sometimes still produce errors
-> unless authors include the usual `@Nullable` annotation on the parameter.
+> Because of the special case [above](#augmented-type-of-usage) that makes record
+> `equals` parameters always nullable, we include this rule so that tools can produce
+> expected errors in some cases when the parameter is not annotated with `@Nullable`.
 
 If a type usage is the parameter of `equals(Object)` in a subclass of
 `java.lang.Record`, then:

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -384,7 +384,7 @@ condition is met, skip the remaining conditions.
     > rules behave as if neither annotation is present.
 
 -   If the type usage is the parameter of `equals(Object)` in a subclass of
-    `java.lang.Record`, then its nullness operator is `UNSPECIFIED`.
+    `java.lang.Record`, then its nullness operator is `UNION_NULL`.
 
     > This special case handles the fact that the Java compiler automatically
     > generates an implementation of `equals` in `Record` but does not include a
@@ -1037,6 +1037,21 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
     its nullness operator is `NO_CHANGE`.
 
     > See ["Augmented null types."](#null-types)
+
+## Harmonizing annotations on special type usages {#harmoize-annotations}
+
+> Because of a special case [above][#augmented-type-of-usage] that makes record
+> `equals` parameters nullable, there is a mismatch between what `public boolean
+> equals(Object o)` means in a record class and what it would otherwise mean. To
+> harmonize this, we anticipate that tools will sometimes still produce errors
+> unless authors include the usual `@Nullable` annotation on the parameter.
+
+If a type usage is the parameter of `equals(Object)` in a subclass of
+`java.lang.Record`, then:
+
+-   It is not expected to be annotated with `@NonNull`.
+-   If it appears in null-marked code, or if this rule is required to hold in
+    [all worlds], then it is expected to be annotated with `@Nullable`.
 
 [#100]: https://github.com/jspecify/jspecify/issues/100
 [#157]: https://github.com/jspecify/jspecify/issues/157


### PR DESCRIPTION
I chose to write a rule directly about the _type usage_ that is the
parameter, rather than to write a rule that makes the whole method a
null-unmarked scope as I'd been discussing in the issue thread. I did
this so that at least the _implementation_ can remain null-marked if the
class is.

~One arguable theoretical downside to that choice is that even the
parameter's nullness-would be unspecified even in the case of:~

```
@NullMarked record Foo() {
  @NullMarked public boolean equals(Object o) { ... }
}
```

~But it would _also_ be weird if the method-level `@NullMarked` _had_ an
effect, since it's otherwise redundant with the class-level annotation.
So I'm not worried about that.~

~It would be nice if there were an obvious way to have our cake and eat
it, too, when analyzing the _source code_ for a null-marked record that
declares `equals` explicitly and omits `@Nullable` from its parameter:~

- ~We'd like that to be an error, since the rules otherwise say that the
  type is non-nullable. (This exception for record `equals` methods
  exists only because we can't distinguish compiler-generated `equals`
  methods from handwritten ones when looking at _bytecode_.)~
- ~But we don't want _callers_ to treat the `equals` method differently
  based on whether they happen to be part of the same javac invocation
  as the record class (especially in the presence of incremental
  recompilation and sharded compilation).~

~This PR's solution seems good enough for now, especially since tools can
(and [do](https://errorprone.info/bugpattern/EqualsMissingNullable))
have special cases for suggesting `@Nullable` on `equals` parameters
independent of whether the parameter is currently considered to be
non-null or to have unspecified nullness.~ We can hope that someday Java
will [provide a way to distinguish compiler-generated `equals` methods
from handwritten ones when looking at
bytecode](https://github.com/jspecify/jspecify/issues/301#issuecomment-2012625990).

This PR fixes the easily fixable part of
https://github.com/jspecify/jspecify/issues/301. I am going to see if I
can subsequently easily add at least a non-normative comment about the
other considerations that we're aware of related to bytecode analysis.