### PR TITLE
Deem type-use annotations to be recognized on record-component types.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -231,6 +231,8 @@ exceptions in the subsequent sections:
 
 -   a field type
 
+-   a record component type
+
 -   a type parameter upper bound
 
 -   a non-wildcard type argument


### PR DESCRIPTION
They are [automatically copied everywhere that we'd hope
for](https://openjdk.org/jeps/395#:~:text=Type%20annotations%20on,automatically%20derived%20members.).

I can't seem to find any issue discussions of this, but we cover it in
[the
Javadoc](https://jspecify.dev/docs/api/org/jspecify/annotations/Nullable.html).
