### PR TITLE
Run documentation build for changes to Java sources.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ on:
       - '*gradle*'
       - 'docs/**'
       - 'gradle/**'
+      - 'src/main/**'
+      - 'src/java9/**'
   pull_request:
     branches:
       - main
@@ -21,6 +23,8 @@ on:
       - '*gradle*'
       - 'docs/**'
       - 'gradle/**'
+      - 'src/main/**'
+      - 'src/java9/**'
 
 jobs:
   # Runs on PRs and push to ensure the documentation successfully builds.


### PR DESCRIPTION
...since those affect the generated Javadoc.

The reason that I'm noticing this is that my
https://github.com/jspecify/jspecify/pull/648 is waiting for the "Build
Documentation" CI task to run, but it's not running on account of this
configuration that I approved back in
https://github.com/jspecify/jspecify/pull/541... :)

This PR should address that, but I wonder if the problem runs deeper: I
think that our branch-protection rules might be able to require a CI
task only _unconditionally_. So if we are trying to merge a change that
touches, say, the conformance tests, I'm thinking that GitHub might
require a documentation build for that, even though the build (a)
couldn't be affected by the change and thus (b) wouldn't be run by CI.

We can always wait to see what happens. If we have problems, then we
could consider various approaches:

- We could just override the check when necessary.
- We could remove the merge requirement (while leaving the CI job in
  place for the proper set of paths as a signal to humans during
  merges).
- We could run the doc build on _all_ commits again. (I imagine that
  it's not the long pole relative to the samples and conformance tests,
  anyway, so the important opitimization of #541 was probably the
  "inverse" change to skip those slower jobs during _doc_ changes.)
- We could introduce a secondary "doc build" CI job that runs during
  changes to the samples and conformance tests. It could pass without
  doing any work. (We'd have to make sure that it _doesn't_ run when the
  "real" build is needed.)
