### PR TITLE
Improve explanation of why "the `ImmutableList.Builder` rule" produces `MINUS_NULL`.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -927,7 +927,7 @@ the output of the following operation:
     > demonstrated in
     > https://github.com/jspecify/jspecify-reference-checker/pull/197.
 
-    > The purpose of this special case is to improve behavior in "the
+    > The primary purpose of this special case is to improve behavior in "the
     > `ImmutableList.Builder` case": Because `ImmutableList.Builder.add` always
     > throws `NullPointerException` for a null argument, we would like for
     > `add(null)` to be a compile error, even under lenient tools.
@@ -948,15 +948,14 @@ the output of the following operation:
     > `MINUS_NULL`.
     >
     > The choice between `NO_CHANGE` and `MINUS_NULL` makes little difference
-    > for the parameter types of `ImmutableList.Builder`, but it can matter more
-    > for other APIs' *return types*. For example, consider `@NullMarked class
-    > Foo<E extends @Nullable Object>`, which somewhere uses the type
-    > [`FluentIterable<E>`]. `FluentIterable` has a method `Optional<E>
-    > first()`. Even when `E` is a type like `String UNION_NULL` (or `String
-    > UNSPECIFIED`), we know that `first().get()` will never return `null`. To
-    > surface that information to tools, we need to define our substitution rule
-    > to return `E MINUS_NULL`: If we instead used `E NO_CHANGE`, then the
-    > return type would look like it might include `null`.
+    > for the `ImmutableList.Builder` case and for most other cases. It may
+    > matter only in unusual cases that involve misannotated code. For example,
+    > consider a `@NullMarked class Sequence<E extends @Nullable Object>` that
+    > declares a method `Optional<E> firstNonNull()`. That method *should* be
+    > declared with a return type of `Optional<@NonNull E>`. Still, this spec
+    > rule ensures that `Sequence` can call `firstNonNull().get().toString()`.
+    > That's possible because the rule makes the type of `firstNonNull().get()`
+    > be `E MINUS_NULL`, rather than `E NO_CHANGE`.
 
 -   Otherwise, replace `V` with the output of applying the nullness operator of
     `V` to `Aᵢ`.


### PR DESCRIPTION
I'm actually wondering if we should just cut this discussion entirely.
It's strictly less important than the _main_ explanation of the
`ImmutableList.Builder` rule, and we may remove _that_ explanation in
favor of a link to a doc.

PLus, I think it would be reasonable to argue that "obviously" you use
`MINUS_NULL` because you're substituting for a non-nullable type
parameter. Thus, the explanation I'm giving is a more complicated
explanation of something that users would naturally already expect.

(As for the actual content of the PR: I noticed that I _think_ the
`Sequence` class has to be null-marked (and not _merely_ to have
`extends @Nullable Object` in its type-parameter declaration) in order
for the example to hold up after our decision in
https://github.com/jspecify/jspecify/issues/248. If not for
`@NullMarked`, then the type (sans `IL.B` rule) would be `Optional<E*>`,
and dereferencing `E*` would not be an error to a lenient checker. We
need for the type to be `Optional<E>` (again, sans `IL.B` rule) so that
a dereference would be an error. That way, we demonstrate that the
`IL.B` rule saves us from that false-positive error.)
