### PR TITLE
Make enum constants intrinsically non-nullable.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -391,8 +391,8 @@ condition is met, skip the remaining conditions.
     constant, its nullness operator is `MINUS_NULL`.
 
     > In source code, there is nowhere in the Java grammar for the type of an
-    > enum constant to be written. Still, enum constants have a type,
-    > which is made explicitly visible in the compiled class file.
+    > enum constant to be written. Still, enum constants have a type, which is
+    > made explicitly visible in the compiled class file.
 
 -   If the type usage is a component of a return type in an annnotation
     interface, its nullness operator is `MINUS_NULL`.

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -387,8 +387,8 @@ usage, this section covers only how to determine its [nullness operator].
 To determine the nullness operator, apply the following rules in order. Once one
 condition is met, skip the remaining conditions.
 
--   If the type usage is the type of an enum constant, its nullness operator is
-    `MINUS_NULL`.
+-   If the type usage is the type of the field corresponding to an enum
+    constant, its nullness operator is `MINUS_NULL`.
 
     > In source code, there is nowhere in the Java grammar for the type of an
     > enum constant to be written. Still, enum constants have an implicit type,

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -391,7 +391,7 @@ condition is met, skip the remaining conditions.
     constant, its nullness operator is `MINUS_NULL`.
 
     > In source code, there is nowhere in the Java grammar for the type of an
-    > enum constant to be written. Still, enum constants have an implicit type,
+    > enum constant to be written. Still, enum constants have a type,
     > which is made explicitly visible in the compiled class file.
 
 -   If the type usage is a component of a return type in an annnotation

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -376,9 +376,9 @@ precedence over the general rule here.
 > The rules here should be sufficient for most tools that care about nullness
 > information, from build-time nullness checkers to runtime dependency-injection
 > tools. However, tools that wish to examine class files in greater detail, such
-> as to insert runtime null checks by rewriting bytecode, may encounter some edge
-> cases. For example, `synthetic` methods may not have accurate annotations in
-> their signatures. The same goes for information about implementation code,
+> as to insert runtime null checks by rewriting bytecode, may encounter some
+> edge cases. For example, `synthetic` methods may not have accurate annotations
+> in their signatures. The same goes for information about implementation code,
 > such as local-variable types.
 
 Because the JLS already has rules for determining the [base type] for a type
@@ -386,6 +386,9 @@ usage, this section covers only how to determine its [nullness operator].
 
 To determine the nullness operator, apply the following rules in order. Once one
 condition is met, skip the remaining conditions.
+
+-   If the type usage is the type of an enum constant, its nullness operator is
+    `MINUS_NULL`.
 
 -   If the type usage is a component of a return type in an annnotation
     interface, its nullness operator is `MINUS_NULL`.

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -390,6 +390,10 @@ condition is met, skip the remaining conditions.
 -   If the type usage is the type of an enum constant, its nullness operator is
     `MINUS_NULL`.
 
+    > In source code, there is nowhere in the Java grammar for the type of an
+    > enum constant to be written. Still, enum constants have an implicit type,
+    > which is made explicitly visible in the compiled class file.
+
 -   If the type usage is a component of a return type in an annnotation
     interface, its nullness operator is `MINUS_NULL`.
 


### PR DESCRIPTION
They were already unrecognized locations for nullness annotations, but
now we also specify that they're non-nullable.

(Also, this PR includes a bit of reformatting that I'd apparently missed
in #649.)
