### PR TITLE
Expand contractions and fix typos

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -129,8 +129,8 @@ A nullness operator is one of four values:
 >     -   The type usage `String UNION_NULL` includes `"a"`, `"b"`, `"ab"`,
 >         etc., plus `null`.
 >     -   The type-variable usage `T UNION_NULL` includes all members of the
->         type argument substituted in for `T`, plus `null` if it was not already
->         included.
+>         type argument substituted in for `T`, plus `null` if it was not
+>         already included.
 > -   `MINUS_NULL`: This is the operator produced by putting `@NonNull` on a
 >     type usage.
 >     -   The type usage `String MINUS_NULL` includes `"a"`, `"b"`, `"ab"`,
@@ -720,8 +720,8 @@ The same-type relation is *not* defined to be reflexive or transitive.
     > In short, whether you have a `Predicate<? super String>`, a `Predicate<?
     > super @Nullable String>`, or unannotated code that does not specify the
     > nullness operator for the bound, you can always pass its `test` method a
-    > `String`. (If you want to pass a `@Nullable String`, then you will need for
-    > the bound to be [null-inclusive under every parameterization]. The
+    > `String`. (If you want to pass a `@Nullable String`, then you will need
+    > for the bound to be [null-inclusive under every parameterization]. The
     > existence of the null-inclusiveness rule frees this current rule from
     > having to cover that case.)
 
@@ -750,14 +750,14 @@ or transitive.
 >
 > Therefore, `String UNION_NULL` is a subtype of `String NO_CHANGE`.
 >
-> Yes, it is pretty terrible for something called "subtyping" not to be reflexive
-> or transitive. A more accurate name for this concept would be "consistent," a
-> term used in gradual typing. However, we use "subtyping" anyway. In our
-> defense, we need to name multiple concepts, including not just subtyping but
-> also the [same-type] relation and [containment]. If we were to coin a new term
-> for each, tool authors would need to mentally map between those terms and the
-> analogous Java terms. (Still, yes: Feel free to read terms like "subtyping" as
-> if they have scare quotes around them.)
+> Yes, it is pretty terrible for something called "subtyping" not to be
+> reflexive or transitive. A more accurate name for this concept would be
+> "consistent," a term used in gradual typing. However, we use "subtyping"
+> anyway. In our defense, we need to name multiple concepts, including not just
+> subtyping but also the [same-type] relation and [containment]. If we were to
+> coin a new term for each, tool authors would need to mentally map between
+> those terms and the analogous Java terms. (Still, yes: Feel free to read terms
+> like "subtyping" as if they have scare quotes around them.)
 >
 > Subtyping does end up being transitive when the relation is required to hold
 > in all worlds. And it does end up being reflexive when the relation is

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -26,7 +26,7 @@ questions we can ask for any given type usage:
 1.  Does `@Nullable` appear directly on that type usage?
 2.  What is the [nullness operator] of that type usage?
 3.  Is it reasonable to assume that `null` will not come "out" of it?
-4.  Is it reasonable to assume that `null` can not be put "in" to it?
+4.  Is it reasonable to assume that `null` cannot be put "in" to it?
 
 ### The scope of this spec
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -25,8 +25,8 @@ questions we can ask for any given type usage:
 
 1.  Does `@Nullable` appear directly on that type usage?
 2.  What is the [nullness operator] of that type usage?
-3.  Is it reasonable to assume that `null` won't come "out" of it?
-4.  Is it reasonable to assume that `null` can't be put "in" to it?
+3.  Is it reasonable to assume that `null` will not come "out" of it?
+4.  Is it reasonable to assume that `null` can not be put "in" to it?
 
 ### The scope of this spec
 
@@ -43,7 +43,7 @@ is a subtype of the bound of the type parameter of `List`.
 However, this is up to tool authors, who may have reasons to take a different
 approach. For example:
 
--   Java [places some restrictions that aren't necessary for soundness][#49],
+-   Java [places some restrictions that are not necessary for soundness][#49],
     and it
     [is lenient in at least one way that can lead to runtime errors][#65].
 
@@ -129,7 +129,7 @@ A nullness operator is one of four values:
 >     -   The type usage `String UNION_NULL` includes `"a"`, `"b"`, `"ab"`,
 >         etc., plus `null`.
 >     -   The type-variable usage `T UNION_NULL` includes all members of the
->         type argument substituted in for `T`, plus `null` if it wasn't already
+>         type argument substituted in for `T`, plus `null` if it was not already
 >         included.
 > -   `MINUS_NULL`: This is the operator produced by putting `@NonNull` on a
 >     type usage.
@@ -144,7 +144,7 @@ A nullness operator is one of four values:
 >         without including `null`. (This is equivalent to `String MINUS_NULL`.)
 >     -   The type-variable usage `T NO_CHANGE` includes exactly the members of
 >         the type argument substituted in for `T`: If `null` was a member of
->         the type argument, then it's a member of `T NO_CHANGE`. If it was not
+>         the type argument, then it is a member of `T NO_CHANGE`. If it was not
 >         a member of the type argument, then it is not a member of `T
 >         NO_CHANGE`.
 > -   `UNSPECIFIED`: This is the operator produced by "completely unannotated
@@ -153,7 +153,7 @@ A nullness operator is one of four values:
 >         etc., but whether `null` should be included is not specified.
 >     -   The type-variable usage `T UNSPECIFIED` includes all members of `T`,
 >         except that there is no specification of whether `null` should be
->         added to the set (if it isn't already a member), removed (if it is
+>         added to the set (if it is not already a member), removed (if it is
 >         already a member), or included only when the substituted type argument
 >         includes it.
 
@@ -338,7 +338,7 @@ innermost.
 
 -   Each class member is enclosed by a class.
 -   Each non-top-level class is enclosed by a class or class member.
--   Each top-level class is enclosed by its package.
+-   Each top-level class is enclosed by a package.
 -   Each package may be enclosed by a module.
 -   Modules are not enclosed by anything.
 
@@ -424,7 +424,7 @@ condition is met, skip the remaining conditions.
 > multiple types. Then the intersection type is derived from those. Intersection
 > types can also arise from operations like [capture conversion]. See [JLS 4.9].
 >
-> One result of this is that it's never possible for a programmer to write an
+> One result of this is that it is never possible for a programmer to write an
 > annotation "on an intersection type."
 
 This spec assigns a [nullness operator] to each individual element of an
@@ -559,7 +559,7 @@ rules.
 > Still another possibility is for a tool to implement both versions and to use
 > that to distinguish between "errors" and "warnings." Such a tool might always
 > first process code with the all-worlds version and then with the some-world
-> version. If the tools detects, say, an out-of-bounds type argument in both
+> version. If the tool detects, say, an out-of-bounds type argument in both
 > cases, the tool would produce an error. But, if the tool detects such a
 > problem with the all-worlds version but not with the some-world version, the
 > tool would produce a warning. Under this scheme, a warning means roughly that
@@ -602,7 +602,7 @@ a target nullness operator `t`* if either of the following conditions holds:
 >
 > -   If the nullness operator *is* `UNION_NULL`, then the assignment should
 >     clearly be allowed.
-> -   If the nullness operator is `UNSPECIFIED`, then it's possible that the
+> -   If the nullness operator is `UNSPECIFIED`, then it is possible that the
 >     operator "ought to be" `UNION_NULL`. A lenient tool might allow the
 >     assignment anyway, while a strict tool might not.
 
@@ -623,7 +623,7 @@ nullness operator `t`* if either of the following conditions holds:
 >
 > -   If the nullness operator *is* `UNION_NULL`, then the dereference clearly
 >     should not be allowed.
-> -   If the nullness operator is `UNSPECIFIED`, then it's possible that the
+> -   If the nullness operator is `UNSPECIFIED`, then it is possible that the
 >     operator "ought to be" `UNION_NULL`. A lenient tool might allow the
 >     dereference anyway, while a strict tool might not.
 
@@ -718,9 +718,9 @@ The same-type relation is *not* defined to be reflexive or transitive.
     > by capture conversion of `? super` wildcards.
     >
     > In short, whether you have a `Predicate<? super String>`, a `Predicate<?
-    > super @Nullable String>`, or unannotated code that doesn't specify the
+    > super @Nullable String>`, or unannotated code that does not specify the
     > nullness operator for the bound, you can always pass its `test` method a
-    > `String`. (If you want to pass a `@Nullable String`, then you'll need for
+    > `String`. (If you want to pass a `@Nullable String`, then you will need for
     > the bound to be [null-inclusive under every parameterization]. The
     > existence of the null-inclusiveness rule frees this current rule from
     > having to cover that case.)
@@ -735,7 +735,7 @@ or transitive.
 
 > If we defined nullness subtyping to be reflexive, then `String UNSPECIFIED`
 > would be a subtype of `String UNSPECIFIED`, even under the [all-worlds] rules.
-> In other words, we'd be saying that unannotated code is always free from
+> In other words, we would be saying that unannotated code is always free from
 > nullness errors. That is clearly false. (Nevertheless, lenient tools will
 > choose not to issue errors for such code. They can do this by implementing the
 > [some-world] rules.)
@@ -750,20 +750,20 @@ or transitive.
 >
 > Therefore, `String UNION_NULL` is a subtype of `String NO_CHANGE`.
 >
-> Yes, it's pretty terrible for something called "subtyping" not to be reflexive
+> Yes, it is pretty terrible for something called "subtyping" not to be reflexive
 > or transitive. A more accurate name for this concept would be "consistent," a
 > term used in gradual typing. However, we use "subtyping" anyway. In our
 > defense, we need to name multiple concepts, including not just subtyping but
 > also the [same-type] relation and [containment]. If we were to coin a new term
 > for each, tool authors would need to mentally map between those terms and the
 > analogous Java terms. (Still, yes: Feel free to read terms like "subtyping" as
-> if they hvae scare quotes around them.)
+> if they have scare quotes around them.)
 >
 > Subtyping does end up being transitive when the relation is required to hold
 > in all worlds. And it does end up being reflexive when the relation is
-> required to hold only in [some world]. We don't state those properties as
+> required to hold only in [some world]. We do not state those properties as
 > rules for two reasons: First, they arise naturally from the definitions.
-> Second, we don't want to suggest that subtyping is reflexive and transitive
+> Second, we do not want to suggest that subtyping is reflexive and transitive
 > under both versions of the rule.
 
 Contrast this with our [nullness-delegating subtyping] rules and [containment]
@@ -774,7 +774,7 @@ extends String>` because of a chain of subtyping rules that uses `String
 UNSPECIFIED` as part of the intermediate step. Luckily, tool authors that set
 out to implement transitivity for these two rules are very unlikely to write
 code that "notices" this chain. So, in practice, users are likely to see the
-"mostly transitive" behavior that we intend, even if we haven't found a way to
+"mostly transitive" behavior that we intend, even if we have not found a way to
 formally specify it yet.
 
 ## Null-inclusive under every parameterization
@@ -797,13 +797,13 @@ following conditions:
 
     > This third case is probably irrelevant in practice: It covers `? super
     > @Nullable Foo`, which is already covered by the rules for
-    > [nullness subtyping]. It's included here in case some tool has reason to
+    > [nullness subtyping]. It is included here in case some tool has reason to
     > check whether a type is null-inclusive under every parameterization
     > *outside* of a check for nullness subtyping.
 
 ## Null-exclusive under every parameterization
 
-> This is a straightforward concept ("never includes `null`"), but it's not as
+> This is a straightforward concept ("never includes `null`"), but it is not as
 > simple to implement as the null-_inclusive_ rule was. This null-_exclusive_
 > rule has to cover cases like `String`, `E` (where `<E extends Object>`), and
 > `E` (where `<E extends @Nullable Object>` but nearby code has performed a null
@@ -816,7 +816,7 @@ A type is null-exclusive under every parameterization if it has a
 -   any type whose [nullness operator] there is reason to be [comfortable]
     treating as `MINUS_NULL`
 
-    > This covers an easy case: A type usage never includes `null` if it's
+    > This covers an easy case: A type usage never includes `null` if it is
     > annotated with `@NonNull`.
 
 -   any augmented class or array type
@@ -848,12 +848,12 @@ hold:
 
 > This section defines the supertypes for a given type—but limited to those that
 > fill the gaps in our nullness checking of "top-level" types. For example,
-> there's no need for the rules to reflect that `String NO_CHANGE` extends
-> `Object NO_CHANGE`: If we've established that a type has a path to `String
-> NO_CHANGE`, then we already know that it's
+> there is no need for the rules to reflect that `String NO_CHANGE` extends
+> `Object NO_CHANGE`: If we have established that a type has a path to `String
+> NO_CHANGE`, then we already know that it is
 > [null-exclusive under every parameterization], based on the rules above, and
-> that's enough to prove subtyping. And if we *haven't* established that, then
-> the `String`-`Object` edge isn't going to change that.
+> that is enough to prove subtyping. And if we *have not* established that, then
+> the `String`-`Object` edge is not going to change that.
 >
 > Thus, the rules here are restricted to type variables and intersection types,
 > whose supertypes may have nullness annotations.


### PR DESCRIPTION
In more formal writing, it is recommended to avoid contractions.
There was also one typo and some regularity that this PR fixes.