### PR TITLE
Add reference to Java version

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -94,6 +94,8 @@ definition.
 In particular, when a JLS rule refers to types, apply this spec's definition of
 [augmented types] \(as opposed to [base types]).
 
+This specification covers all JLS constructs up to Java SE 22.
+
 ## Base type
 
 A *base type* is a type as defined in [JLS 4].

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -94,7 +94,7 @@ definition.
 In particular, when a JLS rule refers to types, apply this spec's definition of
 [augmented types] \(as opposed to [base types]).
 
-This specification covers all JLS constructs up to Java SE 22.
+This specification covers all JLS constructs up to [Java SE 22].
 
 ## Base type
 
@@ -1081,6 +1081,7 @@ If a type usage is the parameter of `equals(Object)` in a subclass of
 
 [#49]: https://github.com/jspecify/jspecify/issues/49
 [#65]: https://github.com/jspecify/jspecify/issues/65
+[Java SE 22]: https://docs.oracle.com/javase/specs/jls/se22/html/index.html
 [JEP 394]: https://openjdk.org/jeps/394
 [JLS 1.3]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-1.html#jls-1.3
 [JLS 4.10.4]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.10.4


### PR DESCRIPTION
I would have expected to see a statement on the supported Java version.
Earlier, there is the sentence "Or the tool might target a future version of Java whose language features would not be covered by this version of this spec."
But there is no explicit statement of what version is supported by this spec.

Maybe also something on future versions should be added? Otherwise, whenever there is a new JLS, we need a corresponding JSpecify spec update.