### PR TITLE
Deem annotations in *all* patterns to be unrecognized.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -252,10 +252,12 @@ However, the type-use annotation is unrecognized in any of the following cases:
 
 -   type arguments of a receiver parameter's type
 
--   any component of the type after the `instanceof` operator
+-   any component of the type after the `instanceof`
+    [type comparison operator][JLS 15.20.2]
 
-    > We may revisit this rule in the future in light of
-    > [Pattern Matching for instanceof][JEP 394].
+-   any component in a [pattern]
+
+    > We are likely to revisit this rule in the future.
 
 All locations that are not explicitly listed as recognized are unrecognized.
 
@@ -1079,8 +1081,8 @@ If a type usage is the parameter of `equals(Object)` in a subclass of
 
 [#49]: https://github.com/jspecify/jspecify/issues/49
 [#65]: https://github.com/jspecify/jspecify/issues/65
-[JEP 394]: https://openjdk.org/jeps/394
 [JLS 1.3]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-1.html#jls-1.3
+[JLS 15.20.2]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-15.html#jls-15.20.2
 [JLS 4.10.4]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.10.4
 [JLS 4.10]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.10
 [JLS 4.3.4]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.3.4
@@ -1120,6 +1122,7 @@ If a type usage is the parameter of `equals(Object)` in a subclass of
 [nullness-delegating subtyping]: #nullness-delegating-subtyping
 [nullness-subtype-establishing direct-supertype edges]: #nullness-subtype-establishing-direct-supertype-edges
 [nullness-subtype-establishing path]: #nullness-subtype-establishing-path
+[pattern]: https://docs.oracle.com/en/java/javase/22/language/pattern-matching.html
 [repeatable]: https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/annotation/Repeatable.html
 [same type]: #same-type
 [same-type]: #same-type


### PR DESCRIPTION
And more clearly distinguish between:
- `instanceof Foo`, the "type comparison operator"
- `instanceof Foo foo`, the "pattern match operator"

(per
https://docs.oracle.com/javase/specs/jls/se22/html/jls-15.html#jls-15.20.2)

This prepares us for:

- possibly someday recognizing annotations in the pattern match operator
  while likely still not recognizing them in the type comparison
  operator, as touched on in
  https://github.com/jspecify/jspecify/issues/626

- claiming to cover all of Java 22, as planned in
  https://github.com/jspecify/jspecify/pull/666
