### PR TITLE
Replay specification-1.0 commits onto main branch.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -823,7 +823,7 @@ hold:
 > Thus, the rules here are restricted to type variables and intersection types,
 > whose supertypes may have nullness annotations.
 
-`T` has nullness-subtype-establishing direct-supertype edges to the all
+`T` has nullness-subtype-establishing direct-supertype edges to all the
 following types, subject to the exception given below:
 
 -   if `T` is an augmented [intersection type]: all the intersection type's

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -405,6 +405,14 @@ condition is met, skip the remaining conditions.
     > If the type usage is annotated with both `@Nullable` and `@NonNull`, these
     > rules behave as if neither annotation is present.
 
+-   If the type usage is the parameter of `equals(Object)` in a subclass of
+    `java.lang.Record`, then its nullness operator is `UNION_NULL`.
+
+    > This special case handles the fact that the Java compiler automatically
+    > generates an implementation of `equals` in `Record` but does not include a
+    > `@Nullable` annotation on its parameter, even when the class is
+    > `@NullMarked`.
+
 -   If the type usage appears in a [null-marked scope], its nullness operator is
     `NO_CHANGE`.
 
@@ -1054,6 +1062,20 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
     its nullness operator is `NO_CHANGE`.
 
     > See ["Augmented null types."](#null-types)
+
+## Expected annotations on record classes' `equals` methods
+
+> Because of the special case [above](#augmented-type-of-usage) that makes
+> parameters of record classes' `equals` methods always nullable, we include
+> this rule so that tools can produce expected errors in some cases when the
+> parameter is not annotated with `@Nullable`.
+
+If a type usage is the parameter of `equals(Object)` in a subclass of
+`java.lang.Record`, then:
+
+-   It is not expected to be annotated with `@NonNull`.
+-   If it appears in null-marked code, or if this rule is required to hold in
+    [all worlds], then it is expected to be annotated with `@Nullable`.
 
 [#49]: https://github.com/jspecify/jspecify/issues/49
 [#65]: https://github.com/jspecify/jspecify/issues/65

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -221,8 +221,8 @@ exceptions in the subsequent sections:
 
 -   the return type of a method
 
--   a formal parameter type of a method or constructor, as defined in [JLS
-    8.4.1]
+-   a formal parameter type of a method or constructor, as defined in
+    [JLS 8.4.1]
 
     > This excludes the receiver parameter but includes variadic parameters.
     > Specifically, you can add `@Nullable` before the `...` token to indicate

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -663,8 +663,8 @@ The same-type relation is *not* defined to be reflexive or transitive.
     > This is the second easy case: `A` never includes `null`.
 
 -   `A` has a [nullness-subtype-establishing path] to any type whose base type
-    is the same as the base type of `F`, and `F` does *not* have
-    [nullness operator] `MINUS_NULL`.
+    is the same as the base type of `F`, and there is *not* reason to be
+    [worried] that `F` has [nullness operator] `MINUS_NULL`.
 
     > This is the first hard case: A given type-variable usage does not
     > necessarily always include `null`, nor does it necessarily always exclude
@@ -672,14 +672,29 @@ The same-type relation is *not* defined to be reflexive or transitive.
     > `ArrayList` may be instantiated as either an `ArrayList<@Nullable String>`
     > or an `ArrayList<String>`.)
     >
-    > Subtyping questions for type-variable usages are more complex: `E` is a
-    > nullness subtype of `E`; `@Nullable E` is not. Similarly, if `<F extends
-    > E>`, then `F` is a nullness subtype of `E`. But if `<F extends @Nullable
-    > E>`, it is not.
+    > Subtyping questions for type-variable usages are more complex. For
+    > example:
+    >
+    > -   `E` is a nullness subtype of `E`; `@Nullable E` is not.
+    > -   Similarly, if `<F extends E>` (in null-marked code), then `F` is a
+    >     nullness subtype of `E`. But if `<F extends @Nullable E>`, it is not.
+    > -   `E` is a nullness subtype of `E` but not of `@NonNull E`.
+    >
+    > When some types have unspecified nullness, the rules become more complex
+    > still:
+    >
+    > -   A declaration like `<F extends E>` might or might not be "intended" to
+    >     be `<F extends @Nullable E>`. Depending on what was indended, `F`
+    >     *might* be intended to be a nullness subtype of `E`.
+    > -   Or that declaration might be "intended" to be `<F extends @NonNull
+    >     E>`. In that [world], `F` would be not only a nullness subtype of `E`
+    >     but a nullness subtype of *all* types, since it would be
+    >     null-exclusive under every parameterization.
 
 -   `F` is a type-variable usage that meets *both* of the following conditions:
 
-    -   It does *not* have nullness operator `MINUS_NULL`.
+    -   There is *not* reason to be worried that it has nullness operator
+        `MINUS_NULL`.
 
     -   `A` is a nullness subtype of its lower bound.
 
@@ -759,7 +774,8 @@ following conditions:
 
 -   It is a type variable that meets *both* of the following conditions:
 
-    -   It does *not* have nullness operator `MINUS_NULL`.
+    -   There is *not* reason to be [worried] that it has nullness operator
+        `MINUS_NULL`.
 
     -   Its lower bound is null-inclusive under every parameterization.
 
@@ -781,7 +797,8 @@ following conditions:
 A type is null-exclusive under every parameterization if it has a
 [nullness-subtype-establishing path] to either of the following:
 
--   any type whose [nullness operator] is `MINUS_NULL`
+-   any type whose [nullness operator] there is reason to be [comfortable]
+    treating as `MINUS_NULL`
 
     > This covers an easy case: A type usage never includes `null` if it's
     > annotated with `@NonNull`.
@@ -981,33 +998,18 @@ The process of applying a [nullness operator] requires two inputs:
 
 The output of the process is an augmented type.
 
-The process is as follows:
+To determine the output, apply the following rules in order.
 
-First, based on the pair of nullness operators (the one to apply and the one
-from the augmented type), compute a "desired nullness operator." Do so by
-applying the following rules in order. Once one condition is met, skip the
-remaining conditions.
+-   If the nullness operator to apply is `NO_CHANGE`, then the output augmented
+    type is the input augmented type.
 
--   If the nullness operator to apply is `MINUS_NULL`, the desired nullness
-    operator is `MINUS_NULL`.
--   If either nullness operator is `UNION_NULL`, the desired nullness operator
-    is `UNION_NULL`.
--   If either nullness operator is `UNSPECIFIED`, the desired nullness operator
-    is `UNSPECIFIED`.
--   The desired nullness operator is `NO_CHANGE`.
+-   Otherwise, if the input augmented type is an [intersection type], then the
+    output is also an intersection type. For every element `Tᵢ` of the input
+    type, the output type has an element that is the output of applying the
+    desired nullness operator to `Tᵢ`.
 
-Then, if the input augmented type is *not* an [intersection type], the output is
-the same as the input but with its nullness operator replaced with the desired
-nullness operator.
-
-Otherwise, the output is an intersection type. For every element `Tᵢ` of the
-input type, the output type has an element that is the output of applying the
-desired nullness operator to `Tᵢ`.
-
-> In this case, the desired nullness operator is always equal to the nullness
-> operator to apply that was an input to this process. That's because the
-> nullness operator of the intersection type itself is defined to always be
-> `NO_CHANGE`.
+-   Otherwise, the output is a type that is the same as the input augmented type
+    except with its nullness operator set to the nullness operator to apply.
 
 ## Capture conversion
 
@@ -1104,5 +1106,6 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 [subtyping]: #subtyping
 [type component]: #type-components
 [type components]: #type-components
+[world]: #multiple-worlds
 [worlds]: #multiple-worlds
 [worried]: #worried

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -15,12 +15,6 @@ introduction for anyone else; instead see our **[Start Here](/docs/start-here)
 page**.
 :::
 
-:::note Status of this specification
-
-This document is current as of JSpecify **0.2.0**, but does not reflect several
-design changes between then and **1.0.0**.
-:::
-
 --------------------------------------------------------------------------------
 
 ### The word "nullable"

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -245,6 +245,9 @@ However, the type-use annotation is unrecognized in any of the following cases:
 
 -   a type usage of a primitive type, since those are intrinsically non-nullable
 
+-   any component of a return type in an annnotation interface, since those are
+    intrinsically non-nullable
+
 -   type arguments of a receiver parameter's type
 
 -   any component of the type after the `instanceof` operator
@@ -373,6 +376,9 @@ usage, this section covers only how to determine its [nullness operator].
 
 To determine the nullness operator, apply the following rules in order. Once one
 condition is met, skip the remaining conditions.
+
+-   If the type usage is a component of a return type in an annnotation
+    interface, its nullness operator is `MINUS_NULL`.
 
 -   If the type usage is annotated with `@Nullable` and *not* with `@NonNull`,
     its nullness operator is `UNION_NULL`.

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -205,7 +205,7 @@ All annotations have runtime retention. None of the annotations are marked
 
 We provide two parameterless type-use annotations: `@Nullable` and `@NonNull`.
 
-### Recognized locations for type-use annotations
+### Recognized locations for type-use annotations {#recognized-type-use}
 
 A location is a *recognized* location for our type-use annotations in the
 circumstances detailed below. If our type-use annotations appear in any other
@@ -312,7 +312,7 @@ All locations that are not explicitly listed as recognized are unrecognized.
 We provide two parameterless declaration annotations: `@NullMarked` and
 `@NullUnmarked`.
 
-### Recognized locations for declaration annotations
+### Recognized locations for declaration annotations {#recognized-declaration}
 
 Our declaration annotations are specified to be *recognized* when applied to the
 locations listed below:
@@ -351,7 +351,8 @@ innermost.
 > defining that there exists a series of enclosing declarations for any type
 > usage, not just for a declaration.
 
-At each declaration, check the following rules in order:
+At each declaration that is a [recognized](#recognized-declaration) location,
+check the following rules in order:
 
 -   If the declaration is annotated with `@NullMarked` and *not* with
     `@NullUnmarked`, the type usage is in a null-marked scope.
@@ -368,10 +369,8 @@ If none of the enclosing declarations meet either rule, then the type usage is
 
 ## Augmented type of a type usage appearing in code {#augmented-type-of-usage}
 
-For most type usages in source code or bytecode on which JSpecify nullness
-annotations are [recognized], this section defines how to determine their
-[augmented types]. Note, however, that rules for specific cases below take
-precedence over the general rule here.
+This section defines how to determine the [augmented types] of most type usages
+in source code or bytecode where JSpecify nullness annotations are [recognized].
 
 > The rules here should be sufficient for most tools that care about nullness
 > information, from build-time nullness checkers to runtime dependency-injection
@@ -1099,7 +1098,6 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 [nullness-delegating subtyping]: #nullness-delegating-subtyping
 [nullness-subtype-establishing direct-supertype edges]: #nullness-subtype-establishing-direct-supertype-edges
 [nullness-subtype-establishing path]: #nullness-subtype-establishing-path
-[recognized]: #recognized-locations-for-type-use-annotations
 [repeatable]: https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/annotation/Repeatable.html
 [same type]: #same-type
 [same-type]: #same-type

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -217,104 +217,96 @@ We provide a parameterless type-use annotation called `@Nullable`.
 ### Recognized locations for type-use annotations
 
 A location is a *recognized* location for our type-use annotation in the
-circumstances detailed below. This spec does not define semantics for
-annotations in other locations.
+circumstances detailed below. If our type-use annotation appears in any other
+location it has no meaning.
 
-> For now, we've chosen to restrict ourselves to API locations for which tools
-> mostly agree on what it means for a type in that location to be `@Nullable`.
->
 > When analyzing source code, tools are encouraged to offer an option to issue
-> an error for an annotation in an unrecognized location (unless they define
-> semantics for that location). Tools are especially encouraged to issue an
-> error for an annotation in a location that is "intrinsically non-nullable"
-> (defined below).
->
-> When reading *bytecode*, however, tools may be best off ignoring an annotation
-> in an unrecognized location (again, unless they define semantics for that
-> location).
+> an error for an annotation in an unrecognized location. When reading
+> *bytecode*, however, tools may be best off ignoring an annotation in an
+> unrecognized location.
 
 The following locations are recognized except when overruled by one of the
-exceptions in the subsequent sections: \[[#17]\]
+exceptions in the subsequent sections:
 
--   return type of a method
+-   the return type of a method
 
--   formal parameter type of a method or constructor, as defined in [JLS 8.4.1]
+-   a formal parameter type of a method or constructor, as defined in [JLS
+    8.4.1]
 
-    > This excludes the receiver parameter.
+    > This excludes the receiver parameter but includes variadic parameters.
+    > Specifically, you can add `@Nullable` before the `...` token to indicate
+    > that a variadic method accepts `null` arrays: `void foo(String @Nullable
+    > ... strings)`.
 
--   field type
+-   a field type
 
--   type parameter upper bound \[[#60]\]
+-   a type parameter upper bound
 
--   non-wildcard type argument
+-   a non-wildcard type argument
 
--   wildcard bound
+-   a wildcard bound
 
--   array component type
+-   an array component type
 
--   type used in a variadic parameter declaration
+-   an array creation expression
 
-However, any location above is unrecognized if it matches either of the
-following cases: \[[#17]\]
+However, the type-use annotation is unrecognized in any of the following cases:
 
-> We refer to these cases (and some other cases below) as "intrinsically
-> non-nullable."
+-   a type usage of a primitive type, since those are intrinsically non-nullable
 
--   a type usage of a value type (currently, the eight predefined primitive
-    types)
-
--   the outer type that qualifies an inner type
-
-    > For example, the annotation in `@Nullable Foo.Bar` is in an unrecognized
-    > location: Java syntax attaches it to the outer type `Foo`.
-    >
-    > (Note that `@Nullable Foo.Bar` is a *Java* syntax error when `Bar` is a
-    > *static* type. If `Bar` is a non-static type, then Java permits the code.
-    > So JSpecify tools have the oppotunity to reject it, given that the author
-    > probably intended `Foo.@Nullable Bar`.)
-
-    > Every outer type is intrinsically non-nullable because every instance of
-    > an inner class has an associated instance of the outer class.
-
-Additionally, any location above is unrecognized if it makes up *any
-[type component]* of a type in the following locations: \[[#17]\]
-
-> These locations all fit under the umbrella of "implementation code."
-> Implementation code may use types that contain type arguments, wildcard
-> bounds, and array component types, which would be recognized locations if not
-> for the exceptions defined by this section.
-
--   a local variable type
--   the type in a cast or `instanceof` expression
--   an array or object creation expression (including via a member reference)
--   an explicit type argument supplied to a generic method or constructor
-    (including via a member reference) or to an instance creation expression for
-    a generic class
-
-> In practice, we anticipate that tools will treat types (and their annotations)
-> in *most* of the above locations much like they treat types in other
-> locations. Still, this spec does not concern itself with implementation code:
-> We believe that the most important domain for us to focus on is that of APIs.
+-   type arguments of a receiver parameter's type
 
 All locations that are not explicitly listed as recognized are unrecognized.
 
-> Other notable unrecognized annotations include: \[[#17]\]
+> Other notable unrecognized annotations include:
 >
-> Some additional intrinsically non-nullable locations:
+> -   class declaration
 >
-> -   supertype in a class declaration
-> -   thrown exception type
-> -   exception parameter type
-> -   enum constant declaration
-> -   receiver parameter type
+>     > For example, the annotation in `public @Nullable class Foo {}` is in an
+>     > unrecognized location.
 >
-> Some other locations that individual tools are more likely to assign semantics
-> to:
+> -   type-parameter declaration or a wildcard *itself*
 >
-> -   a class declaration \[[#7]\]: For example, the annotation in `public
->     @Nullable class Foo {}` is in an unrecognized location.
-> -   a type-parameter declaration or a wildcard *itself* \[[#19], [#31]\]
-> -   any [type component] of a receiver parameter type \[[#157]\]
+> -   local variable's root type
+>
+>     > For example, `@Nullable List<String> strings = ...` or `String @Nullable
+>     > [] strings = ...` have unrecognized annotations.
+>
+> -   root type in a cast of `instanceof` expression
+>
+>     > For example, `(@Nullable List<String>) foo` has an unrecognized
+>     > annotation.
+>
+> -   some additional intrinsically non-nullable locations:
+>
+>     -   supertype in a class declaration
+>
+>     -   thrown exception type
+>
+>     -   exception parameter type
+>
+>     -   enum constant declaration
+>
+>     -   receiver parameter type
+>
+>     -   object creation expression
+>
+>         > For example, `new @Nullable ArrayList<String>()` has an unrecognized
+>         > annotation.
+>
+>     -   outer type qualifying an inner type
+>
+>         > For example, the annotation in `@Nullable Foo.Bar` is unrecognized
+>         > because it is attached to the outer type `Foo`.
+>         >
+>         > (Note that `@Nullable Foo.Bar` is a *Java* syntax error when `Bar`
+>         > is a *static* type. If `Bar` is a non-static type, then Java permits
+>         > the code. So JSpecify tools have the oppotunity to reject it, given
+>         > that the author probably intended `Foo.@Nullable Bar`.)
+>         >
+>         > Every outer type is intrinsically non-nullable because every
+>         > instance of an inner class has an associated instance of the outer
+>         > class.
 >
 > But note that types "inside" some of these locations can still be recognized,
 > such as a *type argument* of a supertype.
@@ -330,10 +322,11 @@ Our declaration annotation is specified to be *recognized* when applied to the
 locations listed below:
 
 -   A *named* class.
--   A package. \[[#34]\]
--   A module. \[[#34]\]
+-   A package.
+-   A module.
+-   A method or constructor.
 
-> *Not* a method \[[#43]\], constructor \[[#43]\], or field \[[#50]\].
+> *Not* a field.
 
 ## Null-marked scope
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -322,7 +322,7 @@ locations listed below:
 -   A module (for `@NullMarked` only, not `@NullUnmarked`).
 -   A method or constructor.
 
-> *Not* a field.
+> *Not* a field or a record component.
 
 If our declaration annotations appear in any other location, they have no
 meaning.

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -247,6 +247,11 @@ However, the type-use annotation is unrecognized in any of the following cases:
 
 -   type arguments of a receiver parameter's type
 
+-   any component of the type after the `instanceof` operator
+
+    > We may revisit this rule in the future in light of
+    > [Pattern Matching for instanceof][JEP 394].
+
 All locations that are not explicitly listed as recognized are unrecognized.
 
 > Other notable unrecognized annotations include:
@@ -262,11 +267,6 @@ All locations that are not explicitly listed as recognized are unrecognized.
 >
 >     > For example, `@Nullable List<String> strings = ...` or `String @Nullable
 >     > [] strings = ...` have unrecognized annotations.
->
-> -   root type in a cast of `instanceof` expression
->
->     > For example, `(@Nullable List<String>) foo` has an unrecognized
->     > annotation.
 >
 > -   some additional intrinsically non-nullable locations:
 >
@@ -1052,6 +1052,7 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 [#80]: https://github.com/jspecify/jspecify/issues/80
 [#87]: https://github.com/jspecify/jspecify/issues/87
 [3-valued logic]: https://en.wikipedia.org/wiki/Three-valued_logic
+[JEP 394]: https://openjdk.org/jeps/394
 [JLS 1.3]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-1.html#jls-1.3
 [JLS 4.10.4]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.10.4
 [JLS 4.10]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.10

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -231,6 +231,8 @@ exceptions in the subsequent sections:
 
 -   a field type
 
+-   a record component type
+
 -   a type parameter upper bound
 
 -   a non-wildcard type argument

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -203,12 +203,12 @@ component of `T` or has `T` as a component.
 
 For all named annotations referred to by this spec:
 
--   The package name is `org.jspecify.nullness`. \[[#260]\]
--   The Java module name is `org.jspecify`. \[[#181]\]
--   The Maven artifact is `org.jspecify:jspecify`. \[[#181]\]
+-   The Java package name is `org.jspecify.annotations`.
+-   The Java module name is `org.jspecify`.
+-   The Maven artifact is `org.jspecify:jspecify`.
 
-All annotations have runtime retention. \[[#28]\] None of the annotations are
-marked [repeatable].
+All annotations have runtime retention. None of the annotations are marked
+[repeatable].
 
 ## The type-use annotation
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -346,12 +346,14 @@ innermost.
 > defining that there exists a series of enclosing declarations for any type
 > usage, not just for a declaration.
 
-At each declaration, check two rules:
+At each declaration, check the following rules in order:
 
 -   If the declaration is annotated with `@NullMarked` and *not* with
     `@NullUnmarked`, the type usage is in a null-marked scope.
 -   If the declaration is annotated with `@NullUnmarked` and *not* with
     `@NullMarked`, the type usage is *not* in a null-marked scope.
+-   If the declaration is a top-level class annotated with `@kotlin.Metadata`,
+    then the type usage is *not* in a null-marked scope.
 
 > If a given declaration is annotated with both `@NullMarked` and
 > `@NullUnmarked`, these rules behave as if neither annotation is present.

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -695,9 +695,9 @@ The same-type relation is *not* defined to be reflexive or transitive.
     > having to cover that case.)
 
 > A further level of complexity in all this is `UNSPECIFIED`. For example, in
-> the [all-worlds] version of the following rules, a type with nullness operator
+> the [some-world] version of the following rules, a type with nullness operator
 > `UNSPECIFIED` can be both null-_inclusive_ under every parameterization and
-> null-_exclusive_ under every parameterization.
+> null-_exclusive_ under every parameterization, albeit in different [worlds].
 
 Nullness subtyping (and thus subtyping itself) is *not* defined to be reflexive
 or transitive.
@@ -1104,4 +1104,5 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 [subtyping]: #subtyping
 [type component]: #type-components
 [type components]: #type-components
+[worlds]: #multiple-worlds
 [worried]: #worried

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -371,6 +371,14 @@ annotations are [recognized], this section defines how to determine their
 [augmented types]. Note, however, that rules for specific cases below take
 precedence over the general rule here.
 
+> The rules here should be sufficient for most tools that care about nullness
+> information, from build-time nullness checkers to runtime dependency-injection
+> tools. However, tools that wish to examine class files in greater detail, such
+> as to insert runtime null checks by rewriting bytecode, may encounter some edge
+> cases. For example, `synthetic` methods may not have accurate annotations in
+> their signatures. The same goes for information about implementation code,
+> such as local-variable types.
+
 Because the JLS already has rules for determining the [base type] for a type
 usage, this section covers only how to determine its [nullness operator].
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -1049,28 +1049,8 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 
     > See ["Augmented null types."](#null-types)
 
-[#100]: https://github.com/jspecify/jspecify/issues/100
-[#157]: https://github.com/jspecify/jspecify/issues/157
-[#17]: https://github.com/jspecify/jspecify/issues/17
-[#181]: https://github.com/jspecify/jspecify/issues/181
-[#19]: https://github.com/jspecify/jspecify/issues/19
-[#1]: https://github.com/jspecify/jspecify/issues/1
-[#260]: https://github.com/jspecify/jspecify/issues/260
-[#28]: https://github.com/jspecify/jspecify/issues/28
-[#31]: https://github.com/jspecify/jspecify/issues/31
-[#33]: https://github.com/jspecify/jspecify/issues/33
-[#34]: https://github.com/jspecify/jspecify/issues/34
-[#43]: https://github.com/jspecify/jspecify/issues/43
 [#49]: https://github.com/jspecify/jspecify/issues/49
-[#50]: https://github.com/jspecify/jspecify/issues/50
-[#5]: https://github.com/jspecify/jspecify/issues/5
-[#60]: https://github.com/jspecify/jspecify/issues/60
 [#65]: https://github.com/jspecify/jspecify/issues/65
-[#69]: https://github.com/jspecify/jspecify/issues/69
-[#7]: https://github.com/jspecify/jspecify/issues/7
-[#80]: https://github.com/jspecify/jspecify/issues/80
-[#87]: https://github.com/jspecify/jspecify/issues/87
-[3-valued logic]: https://en.wikipedia.org/wiki/Three-valued_logic
 [JEP 394]: https://openjdk.org/jeps/394
 [JLS 1.3]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-1.html#jls-1.3
 [JLS 4.10.4]: https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.10.4
@@ -1101,7 +1081,6 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 [in some world]: #multiple-worlds
 [intersection type]: #intersection-types
 [intersection types]: #intersection-types
-[javadoc]: http://jspecify.org/docs/api/org/jspecify/annotations/package-summary.html
 [multiple worlds]: #multiple-worlds
 [null-exclusive under every parameterization]: #null-exclusive-under-every-parameterization
 [null-inclusive under every parameterization]: #null-inclusive-under-every-parameterization
@@ -1114,11 +1093,10 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
 [nullness-subtype-establishing direct-supertype edges]: #nullness-subtype-establishing-direct-supertype-edges
 [nullness-subtype-establishing path]: #nullness-subtype-establishing-path
 [recognized]: #recognized-locations-for-type-use-annotations
-[repeatable]: https://docs.oracle.com/en/java/javase/14/docs/api/java.base/java/lang/annotation/Repeatable.html
+[repeatable]: https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/annotation/Repeatable.html
 [same type]: #same-type
 [same-type]: #same-type
 [semantics]: #semantics
-[shared folder]: https://drive.google.com/drive/folders/1vZl1odNCBncVaN7EwlwfqI05T_CHIqN-
 [some world]: #multiple-worlds
 [some-world]: #multiple-worlds
 [substitution]: #substitution

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -376,9 +376,9 @@ precedence over the general rule here.
 > The rules here should be sufficient for most tools that care about nullness
 > information, from build-time nullness checkers to runtime dependency-injection
 > tools. However, tools that wish to examine class files in greater detail, such
-> as to insert runtime null checks by rewriting bytecode, may encounter some edge
-> cases. For example, `synthetic` methods may not have accurate annotations in
-> their signatures. The same goes for information about implementation code,
+> as to insert runtime null checks by rewriting bytecode, may encounter some
+> edge cases. For example, `synthetic` methods may not have accurate annotations
+> in their signatures. The same goes for information about implementation code,
 > such as local-variable types.
 
 Because the JLS already has rules for determining the [base type] for a type
@@ -386,6 +386,13 @@ usage, this section covers only how to determine its [nullness operator].
 
 To determine the nullness operator, apply the following rules in order. Once one
 condition is met, skip the remaining conditions.
+
+-   If the type usage is the type of the field corresponding to an enum
+    constant, its nullness operator is `MINUS_NULL`.
+
+    > In source code, there is nowhere in the Java grammar for the type of an
+    > enum constant to be written. Still, enum constants have a type, which is
+    > made explicitly visible in the compiled class file.
 
 -   If the type usage is a component of a return type in an annnotation
     interface, its nullness operator is `MINUS_NULL`.

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -308,41 +308,62 @@ All locations that are not explicitly listed as recognized are unrecognized.
 > But note that types "inside" some of these locations can still be recognized,
 > such as a *type argument* of a supertype.
 
-## The declaration annotation
+## The declaration annotations
 
-We provide a single parameterless declaration annotation called `@NullMarked`.
-\[[#5], [#87]\]
+We provide two parameterless declaration annotations: `@NullMarked` and
+`@NullUnmarked`.
 
 ### Recognized locations for declaration annotations
 
-Our declaration annotation is specified to be *recognized* when applied to the
+Our declaration annotations are specified to be *recognized* when applied to the
 locations listed below:
 
 -   A *named* class.
 -   A package.
--   A module.
+-   A module (for `@NullMarked` only, not `@NullUnmarked`).
 -   A method or constructor.
 
 > *Not* a field.
+
+If our declaration annotations appear in any other location, they have no
+meaning.
 
 ## Null-marked scope
 
 To determine whether a type usage appears in a null-marked scope:
 
-Look for a `@NullMarked` annotation on any of the scopes enclosing the type
-usage.
+Iterate over all the declarations that enclose the type usage, starting from the
+innermost.
 
-Class members are enclosed by classes, which may be enclosed by other class
-members or classes. and top-level classes are enclosed by packages, which may be
-enclosed by modules.
+"Enclosing" is defined as follows:
+
+-   Each class member is enclosed by a class.
+-   Each non-top-level class is enclosed by a class or class member.
+-   Each top-level class is enclosed by its package.
+-   Each package may be enclosed by a module.
+-   Modules are not enclosed by anything.
 
 > Packages are *not* enclosed by "parent" packages.
 
-> This definition of "enclosing" likely matches
-> [the definition in the Java compiler API](https://docs.oracle.com/en/java/javase/14/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement\(\)).
+> This definition of "enclosing" largely matches
+> [the definition in the Java compiler API](https://docs.oracle.com/en/java/javase/22/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement\(\)).
+> The JSpecify definition differs slightly by skipping type-parameter
+> declarations (which cannot be annotated with declaration annotations) and by
+> defining that there exists a series of enclosing declarations for any type
+> usage, not just for a declaration.
 
-If one of those scopes is directly annotated with `@NullMarked`, then the type
-usage is in a null-marked scope. Otherwise, it is not.
+At each declaration, check two rules:
+
+-   If the declaration is annotated with `@NullMarked` and *not* with
+    `@NullUnmarked`, the type usage is in a null-marked scope.
+-   If the declaration is annotated with `@NullUnmarked` and *not* with
+    `@NullMarked`, the type usage is *not* in a null-marked scope.
+
+> If a given declaration is annotated with both `@NullMarked` and
+> `@NullUnmarked`, these rules behave as if neither annotation is present.
+
+If none of the enclosing declarations meet either rule, then the type usage is
+*not* in a null-marked scope.
 
 ## Augmented type of a type usage appearing in code {#augmented-type-of-usage}
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -25,8 +25,8 @@ questions we can ask for any given type usage:
 
 1.  Does `@Nullable` appear directly on that type usage?
 2.  What is the [nullness operator] of that type usage?
-3.  Is it reasonable to assume that `null` won't come "out" of it?
-4.  Is it reasonable to assume that `null` can't be put "in" to it?
+3.  Is it reasonable to assume that `null` will not come "out" of it?
+4.  Is it reasonable to assume that `null` cannot be put "in" to it?
 
 ### The scope of this spec
 
@@ -43,7 +43,7 @@ is a subtype of the bound of the type parameter of `List`.
 However, this is up to tool authors, who may have reasons to take a different
 approach. For example:
 
--   Java [places some restrictions that aren't necessary for soundness][#49],
+-   Java [places some restrictions that are not necessary for soundness][#49],
     and it
     [is lenient in at least one way that can lead to runtime errors][#65].
 
@@ -129,8 +129,8 @@ A nullness operator is one of four values:
 >     -   The type usage `String UNION_NULL` includes `"a"`, `"b"`, `"ab"`,
 >         etc., plus `null`.
 >     -   The type-variable usage `T UNION_NULL` includes all members of the
->         type argument substituted in for `T`, plus `null` if it wasn't already
->         included.
+>         type argument substituted in for `T`, plus `null` if it was not
+>         already included.
 > -   `MINUS_NULL`: This is the operator produced by putting `@NonNull` on a
 >     type usage.
 >     -   The type usage `String MINUS_NULL` includes `"a"`, `"b"`, `"ab"`,
@@ -144,7 +144,7 @@ A nullness operator is one of four values:
 >         without including `null`. (This is equivalent to `String MINUS_NULL`.)
 >     -   The type-variable usage `T NO_CHANGE` includes exactly the members of
 >         the type argument substituted in for `T`: If `null` was a member of
->         the type argument, then it's a member of `T NO_CHANGE`. If it was not
+>         the type argument, then it is a member of `T NO_CHANGE`. If it was not
 >         a member of the type argument, then it is not a member of `T
 >         NO_CHANGE`.
 > -   `UNSPECIFIED`: This is the operator produced by "completely unannotated
@@ -153,7 +153,7 @@ A nullness operator is one of four values:
 >         etc., but whether `null` should be included is not specified.
 >     -   The type-variable usage `T UNSPECIFIED` includes all members of `T`,
 >         except that there is no specification of whether `null` should be
->         added to the set (if it isn't already a member), removed (if it is
+>         added to the set (if it is not already a member), removed (if it is
 >         already a member), or included only when the substituted type argument
 >         includes it.
 
@@ -338,7 +338,7 @@ innermost.
 
 -   Each class member is enclosed by a class.
 -   Each non-top-level class is enclosed by a class or class member.
--   Each top-level class is enclosed by its package.
+-   Each top-level class is enclosed by a package.
 -   Each package may be enclosed by a module.
 -   Modules are not enclosed by anything.
 
@@ -438,7 +438,7 @@ condition is met, skip the remaining conditions.
 > multiple types. Then the intersection type is derived from those. Intersection
 > types can also arise from operations like [capture conversion]. See [JLS 4.9].
 >
-> One result of this is that it's never possible for a programmer to write an
+> One result of this is that it is never possible for a programmer to write an
 > annotation "on an intersection type."
 
 This spec assigns a [nullness operator] to each individual element of an
@@ -573,7 +573,7 @@ rules.
 > Still another possibility is for a tool to implement both versions and to use
 > that to distinguish between "errors" and "warnings." Such a tool might always
 > first process code with the all-worlds version and then with the some-world
-> version. If the tools detects, say, an out-of-bounds type argument in both
+> version. If the tool detects, say, an out-of-bounds type argument in both
 > cases, the tool would produce an error. But, if the tool detects such a
 > problem with the all-worlds version but not with the some-world version, the
 > tool would produce a warning. Under this scheme, a warning means roughly that
@@ -616,7 +616,7 @@ a target nullness operator `t`* if either of the following conditions holds:
 >
 > -   If the nullness operator *is* `UNION_NULL`, then the assignment should
 >     clearly be allowed.
-> -   If the nullness operator is `UNSPECIFIED`, then it's possible that the
+> -   If the nullness operator is `UNSPECIFIED`, then it is possible that the
 >     operator "ought to be" `UNION_NULL`. A lenient tool might allow the
 >     assignment anyway, while a strict tool might not.
 
@@ -637,7 +637,7 @@ nullness operator `t`* if either of the following conditions holds:
 >
 > -   If the nullness operator *is* `UNION_NULL`, then the dereference clearly
 >     should not be allowed.
-> -   If the nullness operator is `UNSPECIFIED`, then it's possible that the
+> -   If the nullness operator is `UNSPECIFIED`, then it is possible that the
 >     operator "ought to be" `UNION_NULL`. A lenient tool might allow the
 >     dereference anyway, while a strict tool might not.
 
@@ -732,10 +732,10 @@ The same-type relation is *not* defined to be reflexive or transitive.
     > by capture conversion of `? super` wildcards.
     >
     > In short, whether you have a `Predicate<? super String>`, a `Predicate<?
-    > super @Nullable String>`, or unannotated code that doesn't specify the
+    > super @Nullable String>`, or unannotated code that does not specify the
     > nullness operator for the bound, you can always pass its `test` method a
-    > `String`. (If you want to pass a `@Nullable String`, then you'll need for
-    > the bound to be [null-inclusive under every parameterization]. The
+    > `String`. (If you want to pass a `@Nullable String`, then you will need
+    > for the bound to be [null-inclusive under every parameterization]. The
     > existence of the null-inclusiveness rule frees this current rule from
     > having to cover that case.)
 
@@ -749,7 +749,7 @@ or transitive.
 
 > If we defined nullness subtyping to be reflexive, then `String UNSPECIFIED`
 > would be a subtype of `String UNSPECIFIED`, even under the [all-worlds] rules.
-> In other words, we'd be saying that unannotated code is always free from
+> In other words, we would be saying that unannotated code is always free from
 > nullness errors. That is clearly false. (Nevertheless, lenient tools will
 > choose not to issue errors for such code. They can do this by implementing the
 > [some-world] rules.)
@@ -764,20 +764,20 @@ or transitive.
 >
 > Therefore, `String UNION_NULL` is a subtype of `String NO_CHANGE`.
 >
-> Yes, it's pretty terrible for something called "subtyping" not to be reflexive
-> or transitive. A more accurate name for this concept would be "consistent," a
-> term used in gradual typing. However, we use "subtyping" anyway. In our
-> defense, we need to name multiple concepts, including not just subtyping but
-> also the [same-type] relation and [containment]. If we were to coin a new term
-> for each, tool authors would need to mentally map between those terms and the
-> analogous Java terms. (Still, yes: Feel free to read terms like "subtyping" as
-> if they hvae scare quotes around them.)
+> Yes, it is pretty terrible for something called "subtyping" not to be
+> reflexive or transitive. A more accurate name for this concept would be
+> "consistent," a term used in gradual typing. However, we use "subtyping"
+> anyway. In our defense, we need to name multiple concepts, including not just
+> subtyping but also the [same-type] relation and [containment]. If we were to
+> coin a new term for each, tool authors would need to mentally map between
+> those terms and the analogous Java terms. (Still, yes: Feel free to read terms
+> like "subtyping" as if they have scare quotes around them.)
 >
 > Subtyping does end up being transitive when the relation is required to hold
 > in all worlds. And it does end up being reflexive when the relation is
-> required to hold only in [some world]. We don't state those properties as
+> required to hold only in [some world]. We do not state those properties as
 > rules for two reasons: First, they arise naturally from the definitions.
-> Second, we don't want to suggest that subtyping is reflexive and transitive
+> Second, we do not want to suggest that subtyping is reflexive and transitive
 > under both versions of the rule.
 
 Contrast this with our [nullness-delegating subtyping] rules and [containment]
@@ -788,7 +788,7 @@ extends String>` because of a chain of subtyping rules that uses `String
 UNSPECIFIED` as part of the intermediate step. Luckily, tool authors that set
 out to implement transitivity for these two rules are very unlikely to write
 code that "notices" this chain. So, in practice, users are likely to see the
-"mostly transitive" behavior that we intend, even if we haven't found a way to
+"mostly transitive" behavior that we intend, even if we have not found a way to
 formally specify it yet.
 
 ## Null-inclusive under every parameterization
@@ -811,13 +811,13 @@ following conditions:
 
     > This third case is probably irrelevant in practice: It covers `? super
     > @Nullable Foo`, which is already covered by the rules for
-    > [nullness subtyping]. It's included here in case some tool has reason to
+    > [nullness subtyping]. It is included here in case some tool has reason to
     > check whether a type is null-inclusive under every parameterization
     > *outside* of a check for nullness subtyping.
 
 ## Null-exclusive under every parameterization
 
-> This is a straightforward concept ("never includes `null`"), but it's not as
+> This is a straightforward concept ("never includes `null`"), but it is not as
 > simple to implement as the null-_inclusive_ rule was. This null-_exclusive_
 > rule has to cover cases like `String`, `E` (where `<E extends Object>`), and
 > `E` (where `<E extends @Nullable Object>` but nearby code has performed a null
@@ -830,7 +830,7 @@ A type is null-exclusive under every parameterization if it has a
 -   any type whose [nullness operator] there is reason to be [comfortable]
     treating as `MINUS_NULL`
 
-    > This covers an easy case: A type usage never includes `null` if it's
+    > This covers an easy case: A type usage never includes `null` if it is
     > annotated with `@NonNull`.
 
 -   any augmented class or array type
@@ -862,12 +862,12 @@ hold:
 
 > This section defines the supertypes for a given type—but limited to those that
 > fill the gaps in our nullness checking of "top-level" types. For example,
-> there's no need for the rules to reflect that `String NO_CHANGE` extends
-> `Object NO_CHANGE`: If we've established that a type has a path to `String
-> NO_CHANGE`, then we already know that it's
+> there is no need for the rules to reflect that `String NO_CHANGE` extends
+> `Object NO_CHANGE`: If we have established that a type has a path to `String
+> NO_CHANGE`, then we already know that it is
 > [null-exclusive under every parameterization], based on the rules above, and
-> that's enough to prove subtyping. And if we *haven't* established that, then
-> the `String`-`Object` edge isn't going to change that.
+> that is enough to prove subtyping. And if we *have not* established that, then
+> the `String`-`Object` edge is not going to change that.
 >
 > Thus, the rules here are restricted to type variables and intersection types,
 > whose supertypes may have nullness annotations.

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -1031,6 +1031,9 @@ The Java rules are defined in [JLS 5.1.10]. We add to them as follows:
     > This is just a part of our universal rule to treat a bare `?` like `?
     > extends Object`.
 
+-   Whenever the rules generate a usage of a fresh type variable, that usage has
+    nullness operator `NO_CHANGE`.
+
 -   When a rule generates a lower bound that is the null type, we specify that
     its nullness operator is `NO_CHANGE`.
 


### PR DESCRIPTION
(DO NOT MERGE through GitHub? We want some kind of rebase, rather than a merge, I assume similar to what we did in https://github.com/jspecify/jspecify/pull/565 / https://github.com/jspecify/jspecify/pull/573.)

I claim that we should do this now, even if we're going to wait a little bit longer for final reviews before 1.0:

- We are telling people to "review the spec" if they're interested. They're nearly certain to try to read https://jspecify.dev/docs/spec instead of https://github.com/jspecify/jspecify/blob/specification-1.0/docs/docs/spec.md.
- We had wanted a separate branch in order to avoid getting caught with half of the spec reflecting decisions from 0.3 and half of the spec reflecting decisions from 1.0. We have since completed the updates for decisions changed since 0.3 (`Unmarked<@Nullable>` substitution, recognized annotation locations, new annotations). While we will merge some more changes between now and spec 1.0, they reflect other sorts of improvements, not changes in design decisions.
- Whenever we are actively working on two branches, there is overhead and opportunity for merge conflicts.

My plan after "merging" this will be to delete the specification-1.0 branch and see if we can reparent all pending PRs. The sooner we do this, the fewer such PRs we'll have, I hope :)

FYI @wmdietl @kevinb9n 