### PR TITLE
Touch on the syntax for annotating arrays.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -227,7 +227,9 @@ exceptions in the subsequent sections:
     > This excludes the receiver parameter but includes variadic parameters.
     > Specifically, you can add `@Nullable` before the `...` token to indicate
     > that a variadic method accepts `null` arrays: `void foo(String @Nullable
-    > ... strings)`.
+    > ... strings)`. This syntax follows the syntax for normal arrays: A method
+    > that accepts a `null` array is written as `void foo(String @Nullable []
+    > strings)`.
 
 -   a field type
 
@@ -240,6 +242,11 @@ exceptions in the subsequent sections:
 -   a wildcard bound
 
 -   an array component type
+
+    > An array of nullable strings is written `@Nullable String[]`. A variadic
+    > parameter whose type is "array of nullable strings" is written `@Nullable
+    > String...`. Compare this to the syntax for a nullable array of strings,
+    > shown above in the discussion of variadic parameters.
 
 -   an array creation expression
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -224,12 +224,13 @@ exceptions in the subsequent sections:
 -   a formal parameter type of a method or constructor, as defined in
     [JLS 8.4.1]
 
-    > This excludes the receiver parameter but includes variadic parameters (in varargs methods).
-    > Specifically, you can add `@Nullable` before the `...` token to indicate
-    > that a variadic method accepts `null` arrays: `void foo(String @Nullable
-    > ... strings)`. This syntax follows the syntax for normal arrays: A method
-    > that accepts a `null` array is written as `void foo(String @Nullable []
-    > strings)`.
+    > This excludes the receiver parameter but includes variadic parameters (in
+    > varargs methods). Because *components* types are also a recognized
+    > location for annotations, variadic paramters (like arrays) can have
+    > annotations on multiple components. For example, `@NonNull String
+    > @Nullable [] strings` means non-null elements in a nullable array.
+    > Similarly, `void method(@Nullable String @NonNull ... strings) means
+    > nullable elements of a non-null array.
 
 -   a field type
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -224,7 +224,7 @@ exceptions in the subsequent sections:
 -   a formal parameter type of a method or constructor, as defined in
     [JLS 8.4.1]
 
-    > This excludes the receiver parameter but includes variadic parameters.
+    > This excludes the receiver parameter but includes variadic parameters (in varargs methods).
     > Specifically, you can add `@Nullable` before the `...` token to indicate
     > that a variadic method accepts `null` arrays: `void foo(String @Nullable
     > ... strings)`. This syntax follows the syntax for normal arrays: A method


### PR DESCRIPTION
This builds on the work of
https://github.com/jspecify/jspecify/pull/592 in sorta kinda partially
addressing https://github.com/jspecify/jspecify/issues/580, though that
request is more about the user guide.

We do want to save most of this discussion for the user guide and
perhaps [other docs](https://github.com/jspecify/jspecify/issues/550),
but we also want to make clear that this kind of annotating is
_supported_, especially since we already call out the similar case of
varargs.

(@sdeleuze)
