### PR TITLE
Touch on the syntax for annotating arrays.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -240,18 +240,18 @@ exceptions in the subsequent sections:
 
 -   an array component type
 
-    > An array of nullable strings is written `@Nullable String[]`. Similarly, a
-    > variadic parameter whose type is "array of nullable strings" is written
+    > For an array of nullable strings, write `@Nullable String[]`. Similarly,
+    > for a variadic parameter whose type is "array of nullable strings," write
     > `@Nullable String...`.
     >
     > You can annotate array component types independently from the array
-    > itself. The array itself can be annotated in the same cases as any
-    > non-array type in the same position can, albeit with different syntax. For
-    > example, a method parameter could be annotated as `@NonNull String
-    > @Nullable [] strings`, which means `strings` is a nullable array
-    > containing non-null elements. Similarly for variadic parameters, `void
-    > method(@Nullable String @NonNull ... strings)` means `strings` is a
-    > non-null array containing nullable elements.
+    > itself. You can annotate the array itself in the same cases as any
+    > non-array type in the same position, albeit with different syntax. For
+    > example, you can annotate a method parameter as `@NonNull String @Nullable
+    > [] strings`, which means `strings` is a nullable array containing non-null
+    > elements. Similarly for variadic parameters, `void method(@Nullable String
+    > @NonNull ... strings)` means `strings` is a non-null array containing
+    > nullable elements.
 
 -   an array creation expression
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -225,13 +225,8 @@ exceptions in the subsequent sections:
     [JLS 8.4.1]
 
     > This excludes the receiver parameter but includes variadic parameters (in
-    > varargs methods). Because *array component* types are also a recognized
-    > location for annotations, variadic parameters (which are arrays) can have
-    > annotations on the array itself and/or its component type. For example,
-    > `@NonNull String @Nullable [] strings` means `strings` is a nullable array
-    > containing non-null elements. Similarly, `void method(@Nullable String
-    > @NonNull ... strings)` means `strings` is a non-null array containing
-    > nullable elements.
+    > varargs methods). For examples of variadic paramters, see the comment
+    > about array components below.
 
 -   a field type
 
@@ -245,10 +240,17 @@ exceptions in the subsequent sections:
 
 -   an array component type
 
-    > An array of nullable strings is written `@Nullable String[]`. A variadic
-    > parameter whose type is "array of nullable strings" is written `@Nullable
-    > String...`. Compare this to the syntax for a nullable array of strings,
-    > shown above in the discussion of variadic parameters.
+    > An array of nullable strings is written `@Nullable String[]`. Similarly, a
+    > variadic parameter whose type is "array of nullable strings" is written
+    > `@Nullable String...`.
+    >
+    > Additionally, whenever JSpecify recognizes an annotation at a given
+    > location, it also recognizes an annotation on *an array itself* at that
+    > location. For example, a method parameter could be annotated as `@NonNull
+    > String @Nullable [] strings`, which means `strings` is a nullable array
+    > containing non-null elements. Similarly, `void method(@Nullable String
+    > @NonNull ... strings)` means `strings` is a non-null array containing
+    > nullable elements.
 
 -   an array creation expression
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -225,7 +225,7 @@ exceptions in the subsequent sections:
     [JLS 8.4.1]
 
     > This excludes the receiver parameter but includes variadic parameters (in
-    > varargs methods). For examples of variadic paramters, see the comment
+    > varargs methods). For examples of variadic parameters, see the comment
     > about array components below.
 
 -   a field type

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -244,12 +244,12 @@ exceptions in the subsequent sections:
     > variadic parameter whose type is "array of nullable strings" is written
     > `@Nullable String...`.
     >
-    > You can annotate array component types independently from
-    > the array itself. The array itself can be annotated in the
-    > same cases as any non-array type in the same position can, albeit with
-    > different syntax. For example, a method parameter could be annotated as
-    > `@NonNull String @Nullable [] strings`, which means `strings` is a
-    > nullable array containing non-null elements. Similarly for variadic parameters, `void
+    > You can annotate array component types independently from the array
+    > itself. The array itself can be annotated in the same cases as any
+    > non-array type in the same position can, albeit with different syntax. For
+    > example, a method parameter could be annotated as `@NonNull String
+    > @Nullable [] strings`, which means `strings` is a nullable array
+    > containing non-null elements. Similarly for variadic parameters, `void
     > method(@Nullable String @NonNull ... strings)` means `strings` is a
     > non-null array containing nullable elements.
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -227,7 +227,9 @@ exceptions in the subsequent sections:
     > This excludes the receiver parameter but includes variadic parameters.
     > Specifically, you can add `@Nullable` before the `...` token to indicate
     > that a variadic method accepts `null` arrays: `void foo(String @Nullable
-    > ... strings)`.
+    > ... strings)`. This syntax follows the syntax for normal arrays: A method
+    > that accepts a `null` array is written as `void foo(String @Nullable []
+    > strings)`.
 
 -   a field type
 
@@ -240,6 +242,11 @@ exceptions in the subsequent sections:
 -   a wildcard bound
 
 -   an array component type
+
+    > An array of nullable strings is written `@Nullable String[]`. A variadic
+    > parameter whose type is "array of nullable strings" is written `@Nullable
+    > String...`. Compare this to the syntax for a nullable array of strings,
+    > shown above in the discussion of variadic parameters.
 
 -   an array creation expression
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -229,8 +229,8 @@ exceptions in the subsequent sections:
     > location for annotations, variadic paramters (like arrays) can have
     > annotations on multiple components. For example, `@NonNull String
     > @Nullable [] strings` means non-null elements in a nullable array.
-    > Similarly, `void method(@Nullable String @NonNull ... strings) means
-    > nullable elements of a non-null array.
+    > Similarly, `void method(@Nullable String @NonNull ... strings)` means
+    > nullable elements in a non-null array.
 
 -   a field type
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -244,13 +244,14 @@ exceptions in the subsequent sections:
     > variadic parameter whose type is "array of nullable strings" is written
     > `@Nullable String...`.
     >
-    > Additionally, whenever JSpecify recognizes an annotation at a given
-    > location, it also recognizes an annotation on *an array itself* at that
-    > location. For example, a method parameter could be annotated as `@NonNull
-    > String @Nullable [] strings`, which means `strings` is a nullable array
-    > containing non-null elements. Similarly, `void method(@Nullable String
-    > @NonNull ... strings)` means `strings` is a non-null array containing
-    > nullable elements.
+    > The ability to annotate array component types is orthogonal to the ability
+    > to annotate the array itself. The array itself can be annotated in the
+    > same cases as any other type in the same position can, albeit with
+    > different syntax. For example, a method parameter could be annotated as
+    > `@NonNull String @Nullable [] strings`, which means `strings` is a
+    > nullable array containing non-null elements. Similarly, `void
+    > method(@Nullable String @NonNull ... strings)` means `strings` is a
+    > non-null array containing nullable elements.
 
 -   an array creation expression
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -225,12 +225,12 @@ exceptions in the subsequent sections:
     [JLS 8.4.1]
 
     > This excludes the receiver parameter but includes variadic parameters (in
-    > varargs methods). Because *components* types are also a recognized
-    > location for annotations, variadic paramters (like arrays) can have
-    > annotations on multiple components. For example, `@NonNull String
-    > @Nullable [] strings` means non-null elements in a nullable array.
+    > varargs methods). Because *array component* types are also a recognized
+    > location for annotations, variadic parameters (which are arrays) can have
+    > annotations on the array itself and/or its component type. For example, `@NonNull String
+    > @Nullable [] strings` means `strings` is a nullable array containing non-null elements.
     > Similarly, `void method(@Nullable String @NonNull ... strings)` means
-    > nullable elements in a non-null array.
+    > `strings` is a non-null array containing nullable elements.
 
 -   a field type
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -244,12 +244,12 @@ exceptions in the subsequent sections:
     > variadic parameter whose type is "array of nullable strings" is written
     > `@Nullable String...`.
     >
-    > The ability to annotate array component types is orthogonal to the ability
-    > to annotate the array itself. The array itself can be annotated in the
-    > same cases as any other type in the same position can, albeit with
+    > You can annotate array component types independently from
+    > the array itself. The array itself can be annotated in the
+    > same cases as any non-array type in the same position can, albeit with
     > different syntax. For example, a method parameter could be annotated as
     > `@NonNull String @Nullable [] strings`, which means `strings` is a
-    > nullable array containing non-null elements. Similarly, `void
+    > nullable array containing non-null elements. Similarly for variadic parameters, `void
     > method(@Nullable String @NonNull ... strings)` means `strings` is a
     > non-null array containing nullable elements.
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -224,12 +224,13 @@ exceptions in the subsequent sections:
 -   a formal parameter type of a method or constructor, as defined in
     [JLS 8.4.1]
 
-    > This excludes the receiver parameter but includes variadic parameters (in varargs methods).
-    > Specifically, you can add `@Nullable` before the `...` token to indicate
-    > that a variadic method accepts `null` arrays: `void foo(String @Nullable
-    > ... strings)`. This syntax follows the syntax for normal arrays: A method
-    > that accepts a `null` array is written as `void foo(String @Nullable []
-    > strings)`.
+    > This excludes the receiver parameter but includes variadic parameters (in
+    > varargs methods). Because *components* types are also a recognized
+    > location for annotations, variadic paramters (like arrays) can have
+    > annotations on multiple components. For example, `@NonNull String
+    > @Nullable [] strings` means non-null elements in a nullable array.
+    > Similarly, `void method(@Nullable String @NonNull ... strings) means
+    > nullable elements of a non-null array.
 
 -   a field type
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -227,10 +227,11 @@ exceptions in the subsequent sections:
     > This excludes the receiver parameter but includes variadic parameters (in
     > varargs methods). Because *array component* types are also a recognized
     > location for annotations, variadic parameters (which are arrays) can have
-    > annotations on the array itself and/or its component type. For example, `@NonNull String
-    > @Nullable [] strings` means `strings` is a nullable array containing non-null elements.
-    > Similarly, `void method(@Nullable String @NonNull ... strings)` means
-    > `strings` is a non-null array containing nullable elements.
+    > annotations on the array itself and/or its component type. For example,
+    > `@NonNull String @Nullable [] strings` means `strings` is a nullable array
+    > containing non-null elements. Similarly, `void method(@Nullable String
+    > @NonNull ... strings)` means `strings` is a non-null array containing
+    > nullable elements.
 
 -   a field type
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -224,7 +224,7 @@ exceptions in the subsequent sections:
 -   a formal parameter type of a method or constructor, as defined in
     [JLS 8.4.1]
 
-    > This excludes the receiver parameter but includes variadic parameters.
+    > This excludes the receiver parameter but includes variadic parameters (in varargs methods).
     > Specifically, you can add `@Nullable` before the `...` token to indicate
     > that a variadic method accepts `null` arrays: `void foo(String @Nullable
     > ... strings)`. This syntax follows the syntax for normal arrays: A method


### PR DESCRIPTION
This builds on the work of
https://github.com/jspecify/jspecify/pull/592 in sorta kinda partially
addressing https://github.com/jspecify/jspecify/issues/580, though that
request is more about the user guide.

We do want to save most of this discussion for the user guide and
perhaps [other docs](https://github.com/jspecify/jspecify/issues/550),
but we also want to make clear that this kind of annotating is
_supported_, especially since we already call out the similar case of
varargs.

(@sdeleuze)

This PR replaces https://github.com/jspecify/jspecify/pull/670.
