### PR TITLE
Remove the warning about IntelliJ and local variables.

### DIFF
--- a/docs/docs/whether.md
+++ b/docs/docs/whether.md
@@ -52,8 +52,7 @@ they claim about their current and planned JSpecify support.
     but does not yet analyze generics.
 
 *   [IntelliJ IDEA](https://www.jetbrains.com/idea/) supports JSpecify
-    annotations but has incomplete support for generics and some trouble with
-    local variables.
+    annotations but has incomplete support for generics.
 
 *   The [Checker Framework](https://checkerframework.org/) understands
     `@Nullable` and `@NonNull`, but not `@NullMarked` or `@NullUnmarked`.


### PR DESCRIPTION
The issue I was referring to was fixed in IDEA 2024.2.1:
https://youtrack.jetbrains.com/issue/IDEA-348069

(Thanks to @amaembo for asking about this
https://youtrack.jetbrains.com/issue/IDEA-355699/Warning-when-annotating-array-elements-as-nullable-with-JSpecify#focus=Comments-27-10743536.0-0)
