### PR TITLE
Array creation is intrinsically non-null

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -244,6 +244,12 @@ exceptions in the subsequent sections:
 
 -   an array component type
 
+    > Note that this rule recognizes the annotations in `@Nullable String []`
+    > and `String [] @Nullable []`.
+    > Whether the annotation in `String @Nullable []` is recognized depends on
+    > where that type is used - it would e.g. be recognized if that type is
+    > used as a field type.
+
 However, the type-use annotation is unrecognized in any of the following cases:
 
 -   a type usage of a primitive type, since those are intrinsically non-nullable
@@ -299,8 +305,8 @@ All locations that are not explicitly listed as recognized are unrecognized.
 >
 >         > For example, `new String @Nullable [5]` has an unrecognized
 >         > annotation. However, note that the component type in an array
->         > creation expression can be annotated. For example, `new int [5]
->         > @Nullable []` has a recognized annotation.
+>         > creation expression can be annotated. For example, `new @Nullable
+>         > String [5]` has a recognized annotation.
 >
 >     -   outer type qualifying an inner type
 >

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -288,18 +288,16 @@ All locations that are not explicitly listed as recognized are unrecognized.
 >     -   object creation expression
 >
 >         > For example, `new @Nullable ArrayList<String>()` has an unrecognized
->         > annotation.
->         > However, note that type arguments in an object creation expression can
->         > be annotated.
->         > For example, `new ArrayList<@Nullable String>()` has a recognized
->         > annotation.
+>         > annotation. However, note that type arguments in an object creation
+>         > expression can be annotated. For example, `new ArrayList<@Nullable
+>         > String>()` has a recognized annotation.
 >
 >     -   array creation expression
 >
->         > For example, `new String @Nullable [5]` has an unrecognized annotation.
->         > However, note that the component type in an array creation expression
->         > can be annotated.
->         > For example, `new int [5] @Nullable []` has a recognized annotation.
+>         > For example, `new String @Nullable [5]` has an unrecognized
+>         > annotation. However, note that the component type in an array
+>         > creation expression can be annotated. For example, `new int [5]
+>         > @Nullable []` has a recognized annotation.
 >
 >     -   outer type qualifying an inner type
 >

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -245,7 +245,7 @@ exceptions in the subsequent sections:
 -   an array component type
 
     > Note that this rule recognizes the annotations in `@Nullable String []`
-    > and `String [] @Nullable []`. Whether the annotation in `String @Nullable
+    > and `String[] @Nullable []`. Whether the annotation in `String @Nullable
     > []` is recognized depends on where that type is used. For example, it
     > would be recognized if that type were used as a field type.
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -306,7 +306,7 @@ All locations that are not explicitly listed as recognized are unrecognized.
 >         > For example, `new String @Nullable [5]` has an unrecognized
 >         > annotation. However, note that the component type in an array
 >         > creation expression can be annotated. For example, `new @Nullable
->         > String [5]` has a recognized annotation.
+>         > String[5]` has a recognized annotation.
 >
 >     -   outer type qualifying an inner type
 >

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -245,10 +245,9 @@ exceptions in the subsequent sections:
 -   an array component type
 
     > Note that this rule recognizes the annotations in `@Nullable String []`
-    > and `String [] @Nullable []`.
-    > Whether the annotation in `String @Nullable []` is recognized depends on
-    > where that type is used. For example, it would be recognized if that type were
-    > used as a field type.
+    > and `String [] @Nullable []`. Whether the annotation in `String @Nullable
+    > []` is recognized depends on where that type is used. For example, it
+    > would be recognized if that type were used as a field type.
 
 However, the type-use annotation is unrecognized in any of the following cases:
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -241,8 +241,6 @@ exceptions in the subsequent sections:
 
 -   an array component type
 
--   an array creation expression
-
 However, the type-use annotation is unrecognized in any of the following cases:
 
 -   a type usage of a primitive type, since those are intrinsically non-nullable
@@ -291,6 +289,17 @@ All locations that are not explicitly listed as recognized are unrecognized.
 >
 >         > For example, `new @Nullable ArrayList<String>()` has an unrecognized
 >         > annotation.
+>         > However, note that type arguments in an object creation expression can
+>         > be annotated.
+>         > For example, `new ArrayList<@Nullable String>()` has a recognized
+>         > annotation.
+>
+>     -   array creation expression
+>
+>         > For example, `new String @Nullable [5]` has an unrecognized annotation.
+>         > However, note that the component type in an array creation expression
+>         > can be annotated.
+>         > For example, `new int [5] @Nullable []` has a recognized annotation.
 >
 >     -   outer type qualifying an inner type
 >

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -247,7 +247,7 @@ exceptions in the subsequent sections:
     > Note that this rule recognizes the annotations in `@Nullable String []`
     > and `String [] @Nullable []`.
     > Whether the annotation in `String @Nullable []` is recognized depends on
-    > where that type is used - it would e.g. be recognized if that type is
+    > where that type is used. For example, it would be recognized if that type were
     > used as a field type.
 
 However, the type-use annotation is unrecognized in any of the following cases:

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -244,7 +244,7 @@ exceptions in the subsequent sections:
 
 -   an array component type
 
-    > Note that this rule recognizes the annotations in `@Nullable String []`
+    > Note that this rule recognizes the annotations in `@Nullable String[]`
     > and `String[] @Nullable []`. Whether the annotation in `String @Nullable
     > []` is recognized depends on where that type is used. For example, it
     > would be recognized if that type were used as a field type.


### PR DESCRIPTION
A newly created array, like a newly created object, is non-null. So creating a nullable array should make no sense, like creating a nullable object makes no sense.

Or am I missing what case this is covering?

I also added some non-normative examples.