### PR TITLE
Examples of annotation usages in cast expressions

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -297,10 +297,9 @@ All locations that are not explicitly listed as recognized are unrecognized.
 > -   root types in the reference type(s) in a [cast expression][JSL 15.16]
 >
 >     > For example, `String s = (@NonNull String) o;` has an unrecognized
->     > annotation. However, note that type arguments in a cast expression
->     > can be annotated. For example,
->     > `ArrayList<@Nullable String> al = (ArrayList<@Nullable String>) o;`
->     > has a recognized annotation.
+>     > annotation. However, note that type arguments in a cast expression can
+>     > be annotated. For example, `ArrayList<@Nullable String> al =
+>     > (ArrayList<@Nullable String>) o;` has a recognized annotation.
 >
 > -   some additional intrinsically non-nullable locations:
 >

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -294,7 +294,7 @@ All locations that are not explicitly listed as recognized are unrecognized.
 >     > For example, `@Nullable List<String> strings = ...` or `String @Nullable
 >     > [] strings = ...` have unrecognized annotations.
 >
-> -   root types in the reference type(s) in a [cast expression][JSL 15.16]
+> -   root types in the reference type(s) in a [cast expression][JLS 15.16]
 >
 >     > For example, `String s = (@NonNull String) o;` has an unrecognized
 >     > annotation. However, note that type arguments in a cast expression can

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -294,7 +294,7 @@ All locations that are not explicitly listed as recognized are unrecognized.
 >     > For example, `@Nullable List<String> strings = ...` or `String @Nullable
 >     > [] strings = ...` have unrecognized annotations.
 >
-> -   root types in the reference type(s) in a [cast expression][JLS 15.16]
+> -   root type in a reference type in a [cast expression][JLS 15.16]
 >
 >     > For example, `String s = (@NonNull String) o;` has an unrecognized
 >     > annotation. However, note that type arguments in a cast expression can

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -269,11 +269,10 @@ However, the type-use annotation is unrecognized in any of the following cases:
 
 -   type arguments of a receiver parameter's type
 
--   any component of the reference type(s) in a
-    [cast expression][JSL 15.16]
-
 -   any component of the type after the `instanceof`
     [type comparison operator][JLS 15.20.2]
+
+    > We are likely to revisit this rule in the future.
 
 -   any component in a [pattern]
 
@@ -294,6 +293,14 @@ All locations that are not explicitly listed as recognized are unrecognized.
 >
 >     > For example, `@Nullable List<String> strings = ...` or `String @Nullable
 >     > [] strings = ...` have unrecognized annotations.
+>
+> -   root types in the reference type(s) in a [cast expression][JSL 15.16]
+>
+>     > For example, `String s = (@NonNull String) o;` has an unrecognized
+>     > annotation. However, note that type arguments in a cast expression
+>     > can be annotated. For example,
+>     > `ArrayList<@Nullable String> al = (ArrayList<@Nullable String>) o;`
+>     > has a recognized annotation.
 >
 > -   some additional intrinsically non-nullable locations:
 >

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -254,6 +254,9 @@ However, the type-use annotation is unrecognized in any of the following cases:
 
 -   type arguments of a receiver parameter's type
 
+-   any component of the reference type(s) in a
+    [cast expression][JSL 15.16]
+
 -   any component of the type after the `instanceof`
     [type comparison operator][JLS 15.20.2]
 
@@ -1085,6 +1088,7 @@ If a type usage is the parameter of `equals(Object)` in a subclass of
 [#65]: https://github.com/jspecify/jspecify/issues/65
 [Java SE 23]: https://docs.oracle.com/javase/specs/jls/se23/html/index.html
 [JLS 1.3]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-1.html#jls-1.3
+[JLS 15.16]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-15.html#jls-15.16
 [JLS 15.20.2]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-15.html#jls-15.20.2
 [JLS 4.10.4]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.10.4
 [JLS 4.10]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.10


### PR DESCRIPTION
`cast` appears only once in `spec.md` before this PR.
Annotations in `instanceof` are unrecognized per #626, #668.
In #252 we decided only real sub-components of a cast expression can be annotated.

This PR contradicts what we decided in #252 and forbids annotations in both instanceof and casts.
The types in both are closely related and we should have similar rules for them.

[This comment](https://github.com/jspecify/jspecify/issues/626#issuecomment-2358825421) suggests not recognizing the instanceof usages until further discussion.
Similarly, we should re-open #252 and not recognize annotations in casts.

Or what discussion about the difference between casts and instanceofs am I forgetting? If there is a reason, a quick note in the spec would be good, as otherwise questions about cast types will linger.

