### PR TITLE
Expand list of declaration locations that are unrecognized

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -321,15 +321,16 @@ We provide two parameterless declaration annotations: `@NullMarked` and
 Our declaration annotations are specified to be *recognized* when applied to the
 locations listed below:
 
--   A *named* class.
+-   A *named* type.
 -   A package.
 -   A module (for `@NullMarked` only, not `@NullUnmarked`).
 -   A method or constructor.
 
-> *Not* a field or a record component.
-
 If our declaration annotations appear in any other location, they have no
 meaning.
+
+> That is, they are *not* recognized on a field, a parameter, a local variable,
+> an annotation interface, a type parameter, or a record component declaration.
 
 ## Null-marked scope
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -104,6 +104,8 @@ A *base type* is a type as defined in [JLS 4].
 > JLS 4 does not consider a type-use annotation to be a part of the type it
 > annotates, so neither does our concept of "base type."
 
+We use *class* for classes, interfaces, enums, annotations, and records.
+
 ## Type components
 
 A *type component* of a given type is a type that transitively forms some part
@@ -171,7 +173,7 @@ corresponding to *each* of its [type components].
 > nullness portion of the type.
 
 For our purposes, base types (and thus augmented types) include not just class
-and interface types, array types, and type variables but also
+types, array types, and type variables but also
 [intersection types] and the null type.
 
 > This spec aims to define rules for augmented types compatible with those that
@@ -345,15 +347,17 @@ We provide two parameterless declaration annotations: `@NullMarked` and
 Our declaration annotations are specified to be *recognized* when applied to the
 locations listed below:
 
--   A *named* type.
--   A package.
--   A module (for `@NullMarked` only, not `@NullUnmarked`).
--   A method or constructor.
+-   A *named* class declaration.
+-   A package declaration.
+-   A module (for `@NullMarked` only, not `@NullUnmarked`) declaration.
+-   A method or constructor declaration.
 
 All locations that are not explicitly listed as recognized are unrecognized.
 
 > That is, they are *not* recognized on a field, a parameter, a local variable,
 > a type parameter, or a record component declaration.
+
+> An anonymous class declaration cannot be annotated with a declaration annotation.
 
 ## Null-marked scope
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -326,8 +326,7 @@ locations listed below:
 -   A module (for `@NullMarked` only, not `@NullUnmarked`).
 -   A method or constructor.
 
-If our declaration annotations appear in any other location, they have no
-meaning.
+All locations that are not explicitly listed as recognized are unrecognized.
 
 > That is, they are *not* recognized on a field, a parameter, a local variable,
 > an annotation interface, a type parameter, or a record component declaration.

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -173,8 +173,8 @@ corresponding to *each* of its [type components].
 > nullness portion of the type.
 
 For our purposes, base types (and thus augmented types) include not just class
-types, array types, and type variables but also
-[intersection types] and the null type.
+types, array types, and type variables but also [intersection types] and the
+null type.
 
 > This spec aims to define rules for augmented types compatible with those that
 > the JLS defines for base types.
@@ -357,7 +357,8 @@ All locations that are not explicitly listed as recognized are unrecognized.
 > That is, they are *not* recognized on a field, a parameter, a local variable,
 > a type parameter, or a record component declaration.
 
-> An anonymous class declaration cannot be annotated with a declaration annotation.
+> An anonymous class declaration cannot be annotated with a declaration
+> annotation.
 
 ## Null-marked scope
 

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -330,7 +330,7 @@ locations listed below:
 All locations that are not explicitly listed as recognized are unrecognized.
 
 > That is, they are *not* recognized on a field, a parameter, a local variable,
-> an annotation interface, a type parameter, or a record component declaration.
+> a type parameter, or a record component declaration.
 
 ## Null-marked scope
 


### PR DESCRIPTION
I found the subset of the declaration locations where annotation locations are unrecognized confusing.
I went through [ElementType](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/lang/annotation/ElementType.java) and list all the places that are unrecognized, in the non-normative part.
(I didn't mention "type use", that should be clear as we talk about declaration annotations.

I also found the "named class" confusing, as it seems to exclude interfaces. I'm not sure "named type" is better... The document in other places makes a distinction between class and interface, so just listing "class" here seems odd.
In some earlier document we explicitly stated that we'll use "class" for all kinds of type declarations. Maybe we should add that to this document? I have the same issue with the definition of enclosing talking about "class members" and "class".
