### PR TITLE
Clarify that JSpecify declaration annotations are meant

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -351,8 +351,8 @@ innermost.
 > This definition of "enclosing" largely matches
 > [the definition in the Java compiler API](https://docs.oracle.com/en/java/javase/23/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement\(\)).
 > The JSpecify definition differs slightly by skipping type-parameter
-> declarations (which cannot be annotated with our declaration annotations) and by
-> defining that there exists a series of enclosing declarations for any type
+> declarations (which cannot be annotated with our declaration annotations) and
+> by defining that there exists a series of enclosing declarations for any type
 > usage, not just for a declaration.
 
 At each declaration that is a [recognized](#recognized-declaration) location,

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -351,7 +351,7 @@ innermost.
 > This definition of "enclosing" largely matches
 > [the definition in the Java compiler API](https://docs.oracle.com/en/java/javase/23/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement\(\)).
 > The JSpecify definition differs slightly by skipping type-parameter
-> declarations (which cannot be annotated with declaration annotations) and by
+> declarations (which cannot be annotated with our declaration annotations) and by
 > defining that there exists a series of enclosing declarations for any type
 > usage, not just for a declaration.
 


### PR DESCRIPTION
Because a declaration annotation with `@Target(ElementType.TYPE_PARAMETER)` can annotate type parameters.

One question about "enclosing": is it clear what the enclosing declaration of type parameters and extends or implements clauses is? The rules talk about "class member", but I'm not sure I would consider those class members.