### PR TITLE
Provide motivation for the `@kotlin.Metadata` rule

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -366,7 +366,7 @@ check the following rules in order:
 > If a given declaration is annotated with both `@NullMarked` and
 > `@NullUnmarked`, these rules behave as if neither annotation is present.
 
-If none of the enclosing declarations meet either rule, then the type usage is
+If none of the enclosing declarations meet any rule, then the type usage is
 *not* in a null-marked scope.
 
 ## Augmented type of a type usage appearing in code {#augmented-type-of-usage}

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -362,8 +362,6 @@ check the following rules in order:
     `@NullUnmarked`, the type usage is in a null-marked scope.
 -   If the declaration is annotated with `@NullUnmarked` and *not* with
     `@NullMarked`, the type usage is *not* in a null-marked scope.
--   If the declaration is a top-level class annotated with `@kotlin.Metadata`,
-    then the type usage is *not* in a null-marked scope.
 
 > If a given declaration is annotated with both `@NullMarked` and
 > `@NullUnmarked`, these rules behave as if neither annotation is present.

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -386,9 +386,33 @@ check the following rules in order:
     `@NullUnmarked`, the type usage is in a null-marked scope.
 -   If the declaration is annotated with `@NullUnmarked` and *not* with
     `@NullMarked`, the type usage is *not* in a null-marked scope.
+-   If the declaration is a top-level class annotated with `@kotlin.Metadata`,
+    then the type usage is *not* in a null-marked scope.
 
 > If a given declaration is annotated with both `@NullMarked` and
 > `@NullUnmarked`, these rules behave as if neither annotation is present.
+
+> The Kotlin compiler emits nullness annotations (currently,
+> non-JSpecify annotations) on root types for method parameters,
+> method returns, and fields, but it does not emit annotations
+> elsewhere. In [some
+> cases](https://youtrack.jetbrains.com/issue/KT-13228), Kotlin allows
+> authors to add nullness annotations in those locations
+> manually. However, in general, Kotlin code is "missing" annotations,
+> so it should not be treated as null-marked. As a pragmatic way to
+> accommodate that, the spec has this rule to treat Kotlin code as
+> null-unmarked, even when the code is located in a null-marked
+> package or module.
+
+> In the future, Kotlin may [emit full nullness
+> information](https://youtrack.jetbrains.com/issue/KT-47417),
+> including a `@NullMarked` annotation at the class level. The spec rule
+> for `@kotlin.Metadata` is formulated so that such code will
+> automatically be treated as null-marked at that point. Additionally,
+> it is formulated so that Kotlin code can be explicitly annotated as
+> `@NullMarked` to override the `@kotlin.Metadata` rule for a class and
+> any nested classes. (Another possibility even today is for tools to
+> read the full Kotlin nullness information from `@kotlin.Metadata`.)
 
 If none of the enclosing declarations meet any rule, then the type usage is
 *not* in a null-marked scope.

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -389,30 +389,31 @@ check the following rules in order:
 -   If the declaration is a top-level class annotated with `@kotlin.Metadata`,
     then the type usage is *not* in a null-marked scope.
 
-> If a given declaration is annotated with both `@NullMarked` and
+> Two of the rules here are worth further discussion.
+>
+> First: If a given declaration is annotated with both `@NullMarked` and
 > `@NullUnmarked`, these rules behave as if neither annotation is present.
-
-> The Kotlin compiler emits nullness annotations (currently,
-> non-JSpecify annotations) on root types for method parameters,
-> method returns, and fields, but it does not emit annotations
-> elsewhere. In [some
-> cases](https://youtrack.jetbrains.com/issue/KT-13228), Kotlin allows
-> authors to add nullness annotations in those locations
-> manually. However, in general, Kotlin code is "missing" annotations,
-> so it should not be treated as null-marked. As a pragmatic way to
-> accommodate that, the spec has this rule to treat Kotlin code as
-> null-unmarked, even when the code is located in a null-marked
-> package or module.
-
-> In the future, Kotlin may [emit full nullness
-> information](https://youtrack.jetbrains.com/issue/KT-47417),
-> including a `@NullMarked` annotation at the class level. The spec rule
-> for `@kotlin.Metadata` is formulated so that such code will
-> automatically be treated as null-marked at that point. Additionally,
-> it is formulated so that Kotlin code can be explicitly annotated as
-> `@NullMarked` to override the `@kotlin.Metadata` rule for a class and
-> any nested classes. (Another possibility even today is for tools to
-> read the full Kotlin nullness information from `@kotlin.Metadata`.)
+>
+> Second: The rule for `@kotlin.Metadata` is a pragmatic compromise. The Kotlin
+> compiler emits nullness annotations (currently, non-JSpecify annotations) on
+> root types for method parameters, method returns, and fields, but it does not
+> emit annotations elsewhere. In
+> [some cases](https://youtrack.jetbrains.com/issue/KT-13228), Kotlin allows
+> authors to add nullness annotations in those locations manually. However, in
+> general, Kotlin code is "missing" annotations, so it should not be treated as
+> null-marked. As a pragmatic way to accommodate that, the spec has this rule to
+> treat Kotlin code as null-unmarked, even when the code is located in a
+> null-marked package or module.
+>
+> In the future, Kotlin may
+> [emit full nullness information](https://youtrack.jetbrains.com/issue/KT-47417),
+> including a `@NullMarked` annotation at the class level. The spec rule for
+> `@kotlin.Metadata` is formulated so that such code will automatically be
+> treated as null-marked at that point. Additionally, it is formulated so that
+> Kotlin code can be explicitly annotated as `@NullMarked` to override the
+> `@kotlin.Metadata` rule for a class and any nested classes. (Another
+> possibility even today is for tools to read the full Kotlin nullness
+> information from `@kotlin.Metadata`.)
 
 If none of the enclosing declarations meet any rule, then the type usage is
 *not* in a null-marked scope.


### PR DESCRIPTION
I missed the discussion of #611 and #637.

I find it a bit odd that Kotlin code is always treated as unmarked, even when it appears within a marked package/module.
Won't this lead to always requiring that Kotlin classes have `@Nullmarked`, even in a package/module that is already `@Nullmarked`?
Wouldn't this make them second-class citizens?

I'm fine with keeping the rule, but would prefer some motivation in the specification document.