### PR TITLE
Make dereference example less potentially misleading.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -616,7 +616,7 @@ a target nullness operator `t`* if either of the following conditions holds:
 > authors make this choice by choosing how to handle "[multiple worlds]."
 >
 > Suppose that a tool wants to determine whether it will allow `null` to be
-> assigned to a field of a given type. To do so, it can ask whether it is
+> assigned to a field of base type `String`. To do so, it can ask whether it is
 > "comfortable" treating the field type's nullness operator like `UNION_NULL`.
 >
 > -   If the nullness operator *is* `UNION_NULL`, then the assignment should
@@ -636,8 +636,8 @@ nullness operator `t`* if either of the following conditions holds:
 
 > "Worried" is the complementary attitude to "[comfortable]" above.
 >
-> Suppose that a tool wants to determine whether to allow an expression of a
-> given type to be dereferenced. To do so, it can ask whether it should be
+> Suppose that a tool wants to determine whether to allow an expression of base
+> type `String` to be dereferenced. To do so, it can ask whether it should be
 > "worried" that the type's nullness operator is `UNION_NULL`.
 >
 > -   If the nullness operator *is* `UNION_NULL`, then the dereference clearly


### PR DESCRIPTION
To check whether an expression should be dereferenced, a tool should
check whether it is null-exclusive under every parameterization. (The
spec says as much elsewhere.) But the text here could be read as
suggesting that the tool need only check the nullness operator.

Checking only the nullness operator is sufficient as long as the type
isn't a type variable. Thus, the simple fix here is to restrict the
example to a type (here, `String`) that isn't a type variable.
