### PR TITLE
Remove array creation expressions, again

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -260,8 +260,6 @@ exceptions in the subsequent sections:
     > @NonNull ... strings)` means `strings` is a non-null array containing
     > nullable elements.
 
--   an array creation expression
-
 However, the type-use annotation is unrecognized in any of the following cases:
 
 -   a type usage of a primitive type, since those are intrinsically non-nullable


### PR DESCRIPTION
#674 undid the change from #678.
I think this is just a merge issue, as the later text that says array creations are intrinsically non-null is still there.