### PR TITLE
Replace http://jspecify.org with https://jspecify.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An artifact of well-specified annotations to power static analysis checks and
 JVM language interop. Developed by consensus of the partner organizations listed
-at our main web site, [jspecify.org](http://jspecify.org).
+at our main web site, [jspecify.org](https://jspecify.dev).
 
 Our current focus is on annotations for nullness analysis.
 
@@ -14,4 +14,4 @@ finalizes our initial nullness annotations.
 
 ## Things to read
 
-See [jspecify.org/docs/start-here](http://jspecify.org/docs/start-here).
+See [jspecify.org/docs/start-here](https://jspecify.dev/docs/start-here).

--- a/conformance-tests/build.gradle
+++ b/conformance-tests/build.gradle
@@ -87,7 +87,7 @@ publishing {
                 version = project.version
                 name = 'JSpecify Conformance Test Suite'
                 description = 'Assertions and dependencies representing a suite of conformance tests for JSpecify'
-                url = 'http://jspecify.org/'
+                url = 'https://jspecify.dev/'
                 artifact distZip
                 licenses {
                     license {

--- a/docs/docs/start-here.md
+++ b/docs/docs/start-here.md
@@ -116,7 +116,7 @@ videos:
 [file an issue]: https://github.com/jspecify/jspecify/issues/new
 [github]: https://github.com/jspecify/jspecify
 [google group]: https://groups.google.com/g/jspecify-discuss
-[javadoc]: http://jspecify.org/docs/api/org/jspecify/annotations/package-summary.html
+[javadoc]: https://jspecify.dev/docs/api/org/jspecify/annotations/package-summary.html
 [faq]: http://github.com/jspecify/jspecify/wiki/jspecify-faq
 [nullness design faq]: https://github.com/jspecify/jspecify/wiki/nullness-design-FAQ
 [issues]: https://github.com/jspecify/jspecify/issues

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -23,7 +23,7 @@ import {themes as prismThemes} from 'prism-react-renderer';
 const config = {
   title: 'JSpecify',
   tagline: 'Standard Annotations for Java Static Analysis',
-  url: 'http://jspecify.org/',
+  url: 'https://jspecify.dev/',
   baseUrl: '/',
   trailingSlash: true,
   onBrokenLinks: 'throw',
@@ -82,7 +82,7 @@ const config = {
           {to: '/about', label: 'About Us', position: 'left'},
           {to: '/docs/start-here', label: 'Start Here', position: 'left'},
           {
-            href: 'http://jspecify.org/docs/api/org/jspecify/annotations/package-summary.html',
+            href: 'https://jspecify.dev/docs/api/org/jspecify/annotations/package-summary.html',
             label: 'Javadoc',
             position: 'left',
           },
@@ -110,7 +110,7 @@ const config = {
               },
               {
                 label: 'Javadoc',
-                href: 'http://jspecify.org/docs/api/org/jspecify/annotations/package-summary.html',
+                href: 'https://jspecify.dev/docs/api/org/jspecify/annotations/package-summary.html',
               },
               {
                 label: 'Specification',

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -28,7 +28,7 @@ publishing {
                 artifactId = 'jspecify'
                 name = 'JSpecify annotations'
                 description = 'An artifact of well-named and well-specified annotations to power static analysis checks'
-                url = 'http://jspecify.org/'
+                url = 'https://jspecify.dev/'
                 from components.java
                 licenses {
                     license {

--- a/samples/README.md
+++ b/samples/README.md
@@ -64,7 +64,7 @@ the following line.
 
 The first three special comments indicate that JSpecify annotations are applied
 in ways that are
-[unrecognized](http://jspecify.org/spec#recognized-locations-type-use). Tools
+[unrecognized](https://jspecify.dev/spec#recognized-locations-type-use). Tools
 are likely to report an error in the case of the first two, somewhat less likely
 to report an error in the case of the third (since they might choose to give
 their meaning to annotations there), and not *obligated* to do anything for any

--- a/src/main/java/org/jspecify/annotations/NonNull.java
+++ b/src/main/java/org/jspecify/annotations/NonNull.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  * </ul>
  *
  * <p>For a comprehensive introduction to JSpecify, please see <a
- * href="http://jspecify.org">jspecify.org</a>.
+ * href="https://jspecify.dev">jspecify.org</a>.
  *
  * <h2 id="projection">Non-null projection</h2>
  *

--- a/src/main/java/org/jspecify/annotations/NullMarked.java
+++ b/src/main/java/org/jspecify/annotations/NullMarked.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  * times throughout your code.
  *
  * <p>For a comprehensive introduction to JSpecify, please see <a
- * href="http://jspecify.org">jspecify.org</a>.
+ * href="https://jspecify.dev">jspecify.org</a>.
  *
  * <h2 id="effects">Effects of being null-marked</h2>
  *

--- a/src/main/java/org/jspecify/annotations/NullUnmarked.java
+++ b/src/main/java/org/jspecify/annotations/NullUnmarked.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  * a codebase has been fully migrated it would be appropriate to ban use of this annotation.
  *
  * <p>For a comprehensive introduction to JSpecify, please see <a
- * href="http://jspecify.org">jspecify.org</a>.
+ * href="https://jspecify.dev">jspecify.org</a>.
  *
  * <h2>Null-marked and null-unmarked code</h2>
  *

--- a/src/main/java/org/jspecify/annotations/Nullable.java
+++ b/src/main/java/org/jspecify/annotations/Nullable.java
@@ -40,7 +40,7 @@ import java.lang.annotation.Target;
  * }</pre>
  *
  * <p>For a comprehensive introduction to JSpecify, please see <a
- * href="http://jspecify.org">jspecify.org</a>.
+ * href="https://jspecify.dev">jspecify.org</a>.
  *
  * <h2>Meaning per each kind of type usage</h2>
  *

--- a/src/main/java/org/jspecify/annotations/package-info.java
+++ b/src/main/java/org/jspecify/annotations/package-info.java
@@ -15,7 +15,8 @@
  */
 
 /**
- * JSpecify annotations. See <a href="https://jspecify.dev">jspecify.org</a> for general information.
+ * JSpecify annotations. See <a href="https://jspecify.dev">jspecify.org</a> for general
+ * information.
  *
  * <h2>What's here?</h2>
  *

--- a/src/main/java/org/jspecify/annotations/package-info.java
+++ b/src/main/java/org/jspecify/annotations/package-info.java
@@ -15,7 +15,7 @@
  */
 
 /**
- * JSpecify annotations. See <a href="http://jspecify.org">jspecify.org</a> for general information.
+ * JSpecify annotations. See <a href="https://jspecify.dev">jspecify.org</a> for general information.
  *
  * <h2>What's here?</h2>
  *
@@ -29,7 +29,7 @@
  * may be useful: {@link NullUnmarked} and {@link NonNull}, respectively.
  *
  * <p>For a comprehensive introduction to JSpecify, please see <a
- * href="http://jspecify.org">jspecify.org</a>.
+ * href="https://jspecify.dev">jspecify.org</a>.
  *
  * <h2 id="tool-behavior">Note on tool behavior</h2>
  *


### PR DESCRIPTION
I found that URLs in the official site still uses legacy URL with HTTP scheme.
Since `jspecify.org` provides no valid certificates, I suggest using `jspecify.dev` with HTTPS scheme.