### PR TITLE
Update Gradle actions in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,13 +32,13 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
       - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: ${{ matrix.java_version }}
-          cache: gradle
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - run: |
           ./gradlew spotlessCheck build publishToMavenLocal --no-daemon
 
@@ -58,7 +58,7 @@ jobs:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish conformance tests snapshot
         run: ./gradlew publishConformanceTestsPublicationToSonatypeRepository
         env:
@@ -86,18 +86,16 @@ jobs:
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Run Conformance Tests
         if: github.base_ref == 'main' # only PRs onto main
         continue-on-error: true
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: conformanceTests
-          build-root-directory: ${{ env.reference_checker_repo }}
+        working-directory: ${{ env.reference_checker_repo }}
+        run: ./gradlew conformanceTests
       - name: Run Samples Tests
         # only PRs onto samples-google-prototype
         if: github.base_ref == 'samples-google-prototype'
         continue-on-error: true
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: jspecifySamplesTest
-          build-root-directory: ${{ env.reference_checker_repo }}
+        working-directory: ${{ env.reference_checker_repo }}
+        run: ./gradlew jspecifySamplesTest


### PR DESCRIPTION
- Migrates from deprecated v3 version to v4, see https://github.com/gradle/actions/blob/v4/docs/deprecation-upgrade-guide.md
- Omits redundant wrapper-validation-action which is performed by setup-gradle by default, see https://github.com/gradle/actions/blob/v4/docs/setup-gradle.md#gradle-wrapper-validation

Fixes #741 (probably)
The issue is that currently the deprecated v3 https://github.com/gradle/wrapper-validation-action is used. Recent wrapper-validation versions (including v3) have a hardcoded list of known checksums, and in that case don't need to fetch any information from the Gradle site and should not be flaky. The problem is however likely that the list of v3 is too old and does not contain the Gradle wrapper version which is currently used here (>= 8.10), so it needs to fetch information from the Gradle site. At least that is my assumption.

:warning: I have done some basic tests for the workflow in my fork, but if possible please double-check that everything works as desired.