### PR TITLE
Use new Sonatype Central URLs

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -57,13 +57,10 @@ publishing {
 
 nexusPublishing {
     repositories {
-        // The following line causes the `The Project.getConvention() method has been deprecated.` warning.
-        // The `gradle-nexus` plugin still is on [gradle 8.2.1](https://github.com/gradle-nexus/publish-plugin/blob/c2614e3a5fd61008c66633ca061760df8d4a5106/gradle/wrapper/gradle-wrapper.properties#L4).
-        // I tracked down the deprecation warning to the `sonatype` block, but didn't find a way to avoid the warning.
+        // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
         sonatype {
-            // For users registered in Sonatype after 24 Feb 2021
-            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
-            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
Similar change to https://github.com/jspecify/jspecify-reference-checker/pull/220 to ensure the conformance-tests SNAPSHOT artifact is released in the new location.

The string `oss.sonatype` now doesn't appear in the repo, so hopefully this is the only place that needs this change.