### PR TITLE
Avoid having one method that is guaranteed to have been called by the time another method is called.

### DIFF
--- a/samples/IntersectionSupertype.java
+++ b/samples/IntersectionSupertype.java
@@ -37,56 +37,89 @@ interface IntersectionSupertype {
 
   <T extends @Nullable Object & @Nullable Lib> void x8(T t);
 
-  default void useLib(Lib lib) {
-    x0(lib);
-    x1(lib);
-    x2(lib);
-    x3(lib);
-    x4(lib);
-    x5(lib);
-    x6(lib);
-    x7(lib);
-    x8(lib);
+  default void useLib(Lib lib, int i) {
+    switch (i) {
+      case 0:
+        x0(lib);
+      case 1:
+        x1(lib);
+      case 2:
+        x2(lib);
+      case 3:
+        x3(lib);
+      case 4:
+        x4(lib);
+      case 5:
+        x5(lib);
+      case 6:
+        x6(lib);
+      case 7:
+        x7(lib);
+      case 8:
+        x8(lib);
+    }
   }
 
-  default void useLibUnspec(@NullnessUnspecified Lib lib) {
-    // jspecify_nullness_not_enough_information
-    x0(lib);
-    // jspecify_nullness_not_enough_information
-    x1(lib);
-    // jspecify_nullness_not_enough_information
-    x2(lib);
-    // jspecify_nullness_not_enough_information
-    x3(lib);
-    // jspecify_nullness_not_enough_information
-    x4(lib);
-    // jspecify_nullness_not_enough_information
-    x5(lib);
-    // jspecify_nullness_not_enough_information
-    x6(lib);
-    // jspecify_nullness_not_enough_information
-    x7(lib);
-    this.<@Nullable Lib>x8(lib);
+  default void useLibUnspec(@NullnessUnspecified Lib lib, int i) {
+    switch (i) {
+      case 0:
+        // jspecify_nullness_not_enough_information
+        x0(lib);
+      case 1:
+        // jspecify_nullness_not_enough_information
+        x1(lib);
+      case 2:
+        // jspecify_nullness_not_enough_information
+        x2(lib);
+      case 3:
+        // jspecify_nullness_not_enough_information
+        x3(lib);
+      case 4:
+        // jspecify_nullness_not_enough_information
+        x4(lib);
+      case 5:
+        // jspecify_nullness_not_enough_information
+        x5(lib);
+      case 6:
+        // jspecify_nullness_not_enough_information
+        x6(lib);
+      case 7:
+        // jspecify_nullness_not_enough_information
+        x7(lib);
+      case 8:
+        this.<@Nullable Lib>x8(lib);
+    }
   }
 
-  default void useLibUnionNull(@Nullable Lib lib) {
-    // jspecify_nullness_mismatch
-    x0(lib);
-    // jspecify_nullness_mismatch
-    x1(lib);
-    // jspecify_nullness_mismatch
-    x2(lib);
-    // jspecify_nullness_mismatch
-    x3(lib);
-    // jspecify_nullness_not_enough_information
-    x4(lib);
-    // jspecify_nullness_not_enough_information
-    x5(lib);
-    // jspecify_nullness_mismatch
-    x6(lib);
-    // jspecify_nullness_not_enough_information
-    x7(lib);
-    x8(lib);
+  default void useLibUnionNull(@Nullable Lib lib, int i) {
+    switch (i) {
+      case 0:
+        // jspecify_nullness_mismatch
+        x0(lib);
+      case 1:
+        // jspecify_nullness_mismatch
+        x1(lib);
+      case 2:
+        // jspecify_nullness_mismatch
+        x2(lib);
+      case 3:
+        // jspecify_nullness_mismatch
+        x3(lib);
+      case 4:
+        // jspecify_nullness_not_enough_information
+        x4(lib);
+      case 5:
+        // jspecify_nullness_not_enough_information
+        x5(lib);
+      case 6:
+        // jspecify_nullness_mismatch
+        x6(lib);
+      case 7:
+        // jspecify_nullness_not_enough_information
+        x7(lib);
+      case 8:
+        x8(lib);
+    }
   }
 
   interface Lib {}


### PR DESCRIPTION
Currently, we call `x0` first. `x0` declares a non-null parameter type,
so some checkers choose to treat its argument as non-null thereafter.
This affects their checking of subsequent method calls with the same
parameter.

We could try addressing this in other ways, such as by making each call
pass the result of a method call instead of passing the input parameter
that they pass now. (But we might want to call a _different_ method each
time or at least make the call differ somehow (e.g., `x0(input(0))`,
`x1(input(1))`, etc.) to make sure that checkers don't assume that the
method call returns the same value each time!)

The most natural option is probably to split the method up, but that
gets verbose quickly, and it forces us to introduce more methods, to
which we'd likely give very similar names.

However we address this, it [helps
IntelliJ](https://youtrack.jetbrains.com/issue/IDEA-377689/Nullable-incompatibilities.-Calls-with-union-generics#focus=Comments-27-12657014.0-0).
