### PR TITLE
Update try-with-resources tests with test:irrelevant-annotation:NonNull to use @NonNull instead of @Nullable

### DIFF
--- a/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/notnullmarked/Other.java
+++ b/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/notnullmarked/Other.java
@@ -87,7 +87,7 @@ public class Other {
     try (@Nullable AutoCloseable a = () -> {}) {}
     // test:name:NonNull try-with-resources
     // test:irrelevant-annotation:NonNull
-    try (@Nullable AutoCloseable a = () -> {}) {}
+    try (@NonNull AutoCloseable a = () -> {}) {}
   }
 
   /**

--- a/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/nullmarked/Other.java
+++ b/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/nullmarked/Other.java
@@ -87,7 +87,7 @@ public class Other {
     try (@Nullable AutoCloseable a = () -> {}) {}
     // test:name:NonNull try-with-resources
     // test:irrelevant-annotation:NonNull
-    try (@Nullable AutoCloseable a = () -> {}) {}
+    try (@NonNull AutoCloseable a = () -> {}) {}
   }
 
   /**

--- a/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/nullunmarked/Other.java
+++ b/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/nullunmarked/Other.java
@@ -89,7 +89,7 @@ public class Other {
     try (@Nullable AutoCloseable a = () -> {}) {}
     // test:name:NonNull try-with-resources
     // test:irrelevant-annotation:NonNull
-    try (@Nullable AutoCloseable a = () -> {}) {}
+    try (@NonNull AutoCloseable a = () -> {}) {}
   }
 
   /**


### PR DESCRIPTION
Just align try-with-resources tests with their intended `NonNull` expectations.
Replace `@Nullable` with `@NonNull` for try-with-resources resource variables in tests marked with `test:irrelevant-annotation:NonNull`.
Keeps test names, metadata, and behavior consistent; no functional changes outside of annotation correctness in conformance tests.