### PR TITLE
Fix try-with-resources tests to use `@NonNull` where expected.

### DIFF
--- a/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/notnullmarked/Other.java
+++ b/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/notnullmarked/Other.java
@@ -87,7 +87,7 @@ public class Other {
     try (@Nullable AutoCloseable a = () -> {}) {}
     // test:name:NonNull try-with-resources
     // test:irrelevant-annotation:NonNull
-    try (@Nullable AutoCloseable a = () -> {}) {}
+    try (@NonNull AutoCloseable a = () -> {}) {}
   }
 
   /**

--- a/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/nullmarked/Other.java
+++ b/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/nullmarked/Other.java
@@ -87,7 +87,7 @@ public class Other {
     try (@Nullable AutoCloseable a = () -> {}) {}
     // test:name:NonNull try-with-resources
     // test:irrelevant-annotation:NonNull
-    try (@Nullable AutoCloseable a = () -> {}) {}
+    try (@NonNull AutoCloseable a = () -> {}) {}
   }
 
   /**

--- a/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/nullunmarked/Other.java
+++ b/conformance-tests/src/assertions/java/org/jspecify/conformance/tests/irrelevantannotations/nullunmarked/Other.java
@@ -89,7 +89,7 @@ public class Other {
     try (@Nullable AutoCloseable a = () -> {}) {}
     // test:name:NonNull try-with-resources
     // test:irrelevant-annotation:NonNull
-    try (@Nullable AutoCloseable a = () -> {}) {}
+    try (@NonNull AutoCloseable a = () -> {}) {}
   }
 
   /**


### PR DESCRIPTION
This problem was reported by @pyltsinmikhail in
https://github.com/jspecify/jspecify/pull/765.
