### PR TITLE
Disable the configuration cache for publish tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Publish conformance tests snapshot
-        run: ./gradlew publishConformanceTestsPublicationToSonatypeRepository
+        run: ./gradlew publishConformanceTestsPublicationToSonatypeRepository --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.sonatype_username }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.sonatype_password }}


### PR DESCRIPTION
After merging #755 CI failed when trying to publish artifacts, which is not tested in the PR CI.

I looked around a bit and it looks like the Nexus plugin is incompatible with the configuration cache. So, this PR selectively disables the configuration cache.

Tested with `ORG_GRADLE_PROJECT_sonatypeUsername="abc" ORG_GRADLE_PROJECT_sonatypePassword="def" ./gradlew publishConformanceTestsPublicationToSonatypeRepository --no-configuration-cache` which now fails because of invalid credentials, not because of configuration cache issues.

A previous issue/PR mentioned alternative "publish" plugins. Maybe somebody more familiar with those could rewrite this part.