### PR TITLE
Build docs with JDK 25.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     env:
-      JAVA_VERSION: 24
+      JAVA_VERSION: 25
     steps:
       - name: Check out project
         uses: actions/checkout@v5


### PR DESCRIPTION
Compare https://github.com/jspecify/jspecify/pull/737.

This came up in
https://github.com/jspecify/jspecify/issues/484#issuecomment-3316252883.

I notice that JDK 25 fixes https://bugs.openjdk.org/browse/JDK-8345664,
but that's probably not relevant to JSpecify.
