### PR TITLE
Clarifying user-guide type annotations vs type use annotation

### DIFF
--- a/docs/docs/user-guide.md
+++ b/docs/docs/user-guide.md
@@ -63,12 +63,12 @@ nullness of all type usages:
 
 ## `@Nullable` and `@NonNull`
 
-When a type is annotated with [`@Nullable`], it means that a value of the type
+When a type usage is annotated with [`@Nullable`], it means that a value of the given type 
 can be `null`. `@Nullable String x` means that `x` might be `null`. Code that
 uses those values must be able to deal with the `null` case, and it's okay to
 assign `null` to such variables or pass `null` to those parameters.
 
-When a type is annotated with [`@NonNull`], it means that no value of the type
+When a type usage is annotated with [`@NonNull`], it means that no value of the given type 
 should be `null`. `@NonNull String x` means that `x` should never be `null`.
 Code that uses those values can assume they're not `null`, and it's a bad idea
 to assign `null` to those values or pass `null` to those parameters. (See


### PR DESCRIPTION
This change, although it is quite small, I think it is useful, since strictly speaking in these cases we're not annotating the `String` type declaration, we're annotating the type usage.

It just confused me a bit, and I thought it might be a good idea to clarify this.