### PR TITLE
Place `module-info` in the root of the jar.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories { mavenCentral() }
 def javaVersion = JavaLanguageVersion.of(System.env.JAVA_VERSION ?: 11)
 java.toolchain.languageVersion = javaVersion
 
-apply from: "gradle/mrjar.gradle"
+apply from: "gradle/module-info.gradle"
 apply from: "gradle/integration-test.gradle"
 apply from: "gradle/format.gradle"
 apply from: "gradle/publish.gradle"

--- a/gradle/module-info.gradle
+++ b/gradle/module-info.gradle
@@ -15,15 +15,14 @@
  */
 
 /**
- * This build configuration configures project to necessary files to support JEP 238: Multi-Release JAR Files.
- * https://openjdk.java.net/jeps/238
+ * Configures the project to include a module-info.class in the JAR.
  *
- * It puts class files built for Java 9+ into META-INF/versions/9 directory.
- * It also create a manifest file with Multi-Release attribute.
+ * It compiles module-info.java for Java 9+ and places it at the root of the JAR,
+ * while the rest of the classes are compiled for Java 8.
  */
 
 sourceSets {
-    // The source set for classes stored in META-INF/versions/9 directory
+    // The source set for the Java 9+ module-info
     java9 {
         java {
             srcDirs = [
@@ -34,7 +33,7 @@ sourceSets {
                  * because we're creating an empty module.
                  *
                  * But we won't include the main .class files when we place the
-                 * output module-info.class under META-INF/versions/9, thanks
+                 * output module-info.class in the JAR, thanks
                  * to some more configuration below.
                  */
                 'src/main/java'
@@ -52,17 +51,12 @@ tasks.named('compileJava9Java', JavaCompile).configure {
 }
 
 jar {
-    into('META-INF/versions/9') {
-        from(sourceSets.java9.output) {
-            /*
-             * As discussed above, we compiled all the classes again. But all
-             * that we want to include under META-INF/versions/9 is the
-             * module-info.
-             */
-            include 'module-info.class'
-        }
-    }
-    manifest {
-        attributes 'Multi-Release': true
+    from(sourceSets.java9.output) {
+        /*
+         * As discussed above, we compiled all the classes again. But all
+         * that we want to include is the module-info.
+         */
+        include 'module-info.class'
     }
 }
+


### PR DESCRIPTION
...instead of in a multi-release directory.

Fixes https://github.com/jspecify/jspecify/issues/484
