### PR TITLE
Warn that `@NullMarked` on a module has no effect unless users put it on the module path.

### DIFF
--- a/src/main/java/org/jspecify/annotations/NullMarked.java
+++ b/src/main/java/org/jspecify/annotations/NullMarked.java
@@ -82,7 +82,8 @@ import java.lang.annotation.Target;
  *
  * {@code @NullMarked} and {@link NullUnmarked @NullUnmarked} can be used on any package, class,
  * method, or constructor declaration; {@code @NullMarked} can be used on a module declaration as
- * well. Special considerations:
+ * well. ({@link NullUnmarked @NullUnmarked} is not supported on modules, since it's already the
+ * default.) Special considerations:
  *
  * <ul>
  *   <li>To apply this annotation to an entire (single) <b>package</b>, create a <a
@@ -100,8 +101,11 @@ import java.lang.annotation.Target;
  *   <li>Applying this annotation to an instance <b>method</b> of a <i>generic</i> class is
  *       acceptable, but is not recommended because it can lead to some confusing situations.
  *   <li>An advantage of Java <b>modules</b> is that you can make a lot of code null-marked with
- *       just a single annotation (before the {@code module} keyword). {@link NullUnmarked} is not
- *       supported on modules, since it's already the default.
+ *       just a single annotation (before the {@code module} keyword). <b>Warning</b>: Even if you
+ *       annotate the module for a library as {@code @NullMarked}, this has no effect for users who
+ *       place the library on the class path, only those who place the library on the <a
+ *       href="https://openjdk.org/projects/jigsaw/quick-start">module path</a>, which is less
+ *       commonly used.
  *   <li>If both {@code @NullMarked} and {@code @NullUnmarked} appear together on the same element,
  *       <i>neither</i> one is recognized.
  * </ul>

--- a/src/main/java/org/jspecify/annotations/NullMarked.java
+++ b/src/main/java/org/jspecify/annotations/NullMarked.java
@@ -103,7 +103,7 @@ import java.lang.annotation.Target;
  *   <li>An advantage of Java <b>modules</b> is that you can make a lot of code null-marked with
  *       just a single annotation (before the {@code module} keyword). <b>Warning</b>: Even if you
  *       annotate the module for a library as {@code @NullMarked}, this has no effect for users who
- *       place the library on the class path, only those who place the library on the <a
+ *       place the library on the class path; it affects only those who place the library on the <a
  *       href="https://openjdk.org/projects/jigsaw/quick-start">module path</a>, which is less
  *       commonly used.
  *   <li>If both {@code @NullMarked} and {@code @NullUnmarked} appear together on the same element,


### PR DESCRIPTION
Fixes https://github.com/jspecify/jspecify/issues/496
