### PR TITLE
Fix reading environment variables under the Gradle configuration cache.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
 
 repositories { mavenCentral() }
 
-def javaVersion = JavaLanguageVersion.of(System.env.JAVA_VERSION ?: 11)
+def javaVersion = JavaLanguageVersion.of(providers.environmentVariable("JAVA_VERSION").getOrElse("11"))
 java.toolchain.languageVersion = javaVersion
 
 apply from: "gradle/mrjar.gradle"


### PR DESCRIPTION
As I understand it:

Under the current approach, if we run even `JAVA_VERSION=26 ./gradlew clean javadoc`, Gradle can reuse results from any previous run of `./gradlew clean javadoc`, even one with a different `JAVA_VERSION`.

By using [`providers.environmentVariable`](https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.provider/-provider-factory/environment-variable.html) instead of directly accessing `System.env`, we tell Gradle that `JAVA_VERSION` is part of the inputs—and thus that it can't reuse outputs from a run with a different value.

This solves a problem I saw when I accidentally built Javadoc with the default `JAVA_VERSION` (11) and then tried to rebuild with a newer version, only to see no changes.

(previously in the Gradle configuration cache: https://github.com/jspecify/jspecify/pull/769)
