### PR TITLE
Fix links in `tool-conformance`, and enable strict checking of anchors.

### DIFF
--- a/docs/docs/tool-conformance.md
+++ b/docs/docs/tool-conformance.md
@@ -50,14 +50,15 @@ The questions are as follows:
 > **NOTE:** The examples for each question are not meant to be exhaustive.
 
 1.  Is a given JSpecify annotation recognized or unrecognized
-    ([type-use][spec-locations], [declaration][spec-locations]) in its context?
+    ([type-use][spec-type-use-locations],
+    [declaration][spec-declaration-locations]) in its context?
 
     *   Unrecognized: `@Nullable int`
     *   Unrecognized: `class Foo<@NonNull T extends Foo>`
     *   Recognized: `void foo(@Nullable Bar bar)`
 
-1.  What is the [null-augmented type][spec-locations] of a given type usage,
-    based only on JSpecify annotations on it or surrounding scopes?
+1.  What is the [null-augmented type][spec-augmented-type] of a given type
+    usage, based only on JSpecify annotations on it or surrounding scopes?
 
     ```java
     @NullMarked
@@ -157,4 +158,6 @@ all without affecting its conformance to JSpecify.
 [expression context]: https://docs.google.com/document/d/1nbTnJ0-HubLnQPKSjK5CDZyoe6Al64vdlkoJxaYX9XY/preview?resourcekey=0-ADjPZnp8LN3dRX_ptjlagw&tab=t.0#bookmark=kix.w6xfjhkftb9r
 [expression]: https://docs.google.com/document/d/1nbTnJ0-HubLnQPKSjK5CDZyoe6Al64vdlkoJxaYX9XY/preview?resourcekey=0-ADjPZnp8LN3dRX_ptjlagw&tab=t.0#bookmark=kix.2r97mw74ac6r
 [Map.get]: https://github.com/jspecify/jdk/blob/b7435cff373c527aad82a062c5605f6f9c1bb0de/src/java.base/share/classes/java/util/Map.java#L255
-[spec-locations]: /docs/spec#recognized-locations-for-declaration-annotations
+[spec-augmented-type]: /docs/spec#augmented-type
+[spec-declaration-locations]: /docs/spec#recognized-declaration
+[spec-type-use-location]: /docs/spec#recognized-type-use

--- a/docs/docs/tool-conformance.md
+++ b/docs/docs/tool-conformance.md
@@ -57,8 +57,9 @@ The questions are as follows:
     *   Unrecognized: `class Foo<@NonNull T extends Foo>`
     *   Recognized: `void foo(@Nullable Bar bar)`
 
-1.  What is the [null-augmented type][spec-augmented-type] of a given type
-    usage, based only on JSpecify annotations on it or surrounding scopes?
+1.  What is the [null-augmented type][spec-augmented-type] of a
+    [given type usage][spec-augmented-type-of-usage], based only on JSpecify
+    annotations on it or surrounding scopes?
 
     ```java
     @NullMarked
@@ -159,5 +160,6 @@ all without affecting its conformance to JSpecify.
 [expression]: https://docs.google.com/document/d/1nbTnJ0-HubLnQPKSjK5CDZyoe6Al64vdlkoJxaYX9XY/preview?resourcekey=0-ADjPZnp8LN3dRX_ptjlagw&tab=t.0#bookmark=kix.2r97mw74ac6r
 [Map.get]: https://github.com/jspecify/jdk/blob/b7435cff373c527aad82a062c5605f6f9c1bb0de/src/java.base/share/classes/java/util/Map.java#L255
 [spec-augmented-type]: /docs/spec#augmented-type
+[spec-augmented-type-of-usage]: /docs/spec#augmented-type-of-usage
 [spec-declaration-locations]: /docs/spec#recognized-declaration
 [spec-type-use-location]: /docs/spec#recognized-type-use

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -26,6 +26,7 @@ const config = {
   url: 'https://jspecify.dev/',
   baseUrl: '/',
   trailingSlash: true,
+  onBrokenAnchors: 'throw',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   favicon: 'img/jspecify-favicon.ico',


### PR DESCRIPTION
There were two issues:

First, we were pointing to an incorrect anchor:

```
Exhaustive list of all broken anchors found:
[INFO] Use `npm run serve` command to test your build locally.
- Broken anchor on source page path = /docs/tool-conformance/:
   -> linking to /docs/spec/#recognized-locations-for-declaration-annotations
```

Second, we were using that anchor as the destination for a number of links, each of which should have been pointing to a different section.

To detect future instances of the first problem, I've set `onBrokenAnchors: 'throw'` and confirmed that it does as I'd hope:

```
[INFO] Docusaurus version: 3.6.3
  [cause]: Error: Docusaurus found broken anchors!
Node version: v18.17.1

  Please check the pages of your site in the list below, and make sure you don't reference any anchor that does not exist.
  Note: it's possible to ignore broken anchors with the 'onBrokenAnchors' Docusaurus configuration, and let the build pass.
```
