### PR TITLE
Bump more links to Java 26, and remove an unused reference definition.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -1144,7 +1144,7 @@ If a type usage is the parameter of `equals(Object)` in a subclass of
 
 [#49]: https://github.com/jspecify/jspecify/issues/49
 [#65]: https://github.com/jspecify/jspecify/issues/65
-[Java SE 23]: https://docs.oracle.com/javase/specs/jls/se26/html/index.html
+[Java SE 23]: https://docs.oracle.com/javase/specs/jls/se23/html/index.html
 [JLS 1.3]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-1.html#jls-1.3
 [JLS 15.16]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-15.html#jls-15.16
 [JLS 15.20.2]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-15.html#jls-15.20.2

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -384,7 +384,7 @@ innermost.
 > Packages are *not* enclosed by "parent" packages.
 >
 > This definition of "enclosing" largely matches
-> [the definition in the Java compiler API](https://docs.oracle.com/en/java/javase/26/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement\(\)).
+> [the definition in the Java compiler API](https://docs.oracle.com/en/java/javase/23/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement\(\)).
 > The JSpecify definition differs slightly by skipping type-parameter
 > declarations (which cannot be annotated with our declaration annotations) and
 > by defining that there exists a series of enclosing declarations for any type
@@ -1145,21 +1145,21 @@ If a type usage is the parameter of `equals(Object)` in a subclass of
 [#49]: https://github.com/jspecify/jspecify/issues/49
 [#65]: https://github.com/jspecify/jspecify/issues/65
 [Java SE 23]: https://docs.oracle.com/javase/specs/jls/se23/html/index.html
-[JLS 1.3]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-1.html#jls-1.3
-[JLS 15.16]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-15.html#jls-15.16
-[JLS 15.20.2]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-15.html#jls-15.20.2
-[JLS 4.10.4]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.10.4
-[JLS 4.10]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.10
-[JLS 4.3.4]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.3.4
-[JLS 4.4]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.4
-[JLS 4.5.1]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.5.1
-[JLS 4.5.2]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.5.2
-[JLS 4.5]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.5
-[JLS 4.9]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.9
-[JLS 4]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html
-[JLS 5.1.10]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-5.html#jls-5.1.10
-[JLS 8.4.1]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-8.html#jls-8.4.1
-[JLS 8.4.8.1]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-8.html#jls-8.4.8.1
+[JLS 1.3]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-1.html#jls-1.3
+[JLS 15.16]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-15.html#jls-15.16
+[JLS 15.20.2]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-15.html#jls-15.20.2
+[JLS 4.10.4]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.10.4
+[JLS 4.10]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.10
+[JLS 4.3.4]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.3.4
+[JLS 4.4]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.4
+[JLS 4.5.1]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.5.1
+[JLS 4.5.2]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.5.2
+[JLS 4.5]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.5
+[JLS 4.9]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.9
+[JLS 4]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html
+[JLS 5.1.10]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-5.html#jls-5.1.10
+[JLS 8.4.1]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-8.html#jls-8.4.1
+[JLS 8.4.8.1]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-8.html#jls-8.4.8.1
 [`FluentIterable<E>`]: https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/collect/FluentIterable.html
 [all worlds]: #multiple-worlds
 [all-worlds]: #multiple-worlds
@@ -1186,8 +1186,8 @@ If a type usage is the parameter of `equals(Object)` in a subclass of
 [nullness-delegating subtyping]: #nullness-delegating-subtyping
 [nullness-subtype-establishing direct-supertype edges]: #nullness-subtype-establishing-direct-supertype-edges
 [nullness-subtype-establishing path]: #nullness-subtype-establishing-path
-[pattern]: https://docs.oracle.com/en/java/javase/26/language/pattern-matching.html
-[repeatable]: https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/lang/annotation/Repeatable.html
+[pattern]: https://docs.oracle.com/en/java/javase/23/language/pattern-matching.html
+[repeatable]: https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/annotation/Repeatable.html
 [same type]: #same-type
 [same-type]: #same-type
 [semantics]: #semantics

--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -384,7 +384,7 @@ innermost.
 > Packages are *not* enclosed by "parent" packages.
 >
 > This definition of "enclosing" largely matches
-> [the definition in the Java compiler API](https://docs.oracle.com/en/java/javase/23/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement\(\)).
+> [the definition in the Java compiler API](https://docs.oracle.com/en/java/javase/26/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement\(\)).
 > The JSpecify definition differs slightly by skipping type-parameter
 > declarations (which cannot be annotated with our declaration annotations) and
 > by defining that there exists a series of enclosing declarations for any type
@@ -1144,23 +1144,22 @@ If a type usage is the parameter of `equals(Object)` in a subclass of
 
 [#49]: https://github.com/jspecify/jspecify/issues/49
 [#65]: https://github.com/jspecify/jspecify/issues/65
-[Java SE 23]: https://docs.oracle.com/javase/specs/jls/se23/html/index.html
-[JLS 1.3]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-1.html#jls-1.3
-[JLS 15.16]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-15.html#jls-15.16
-[JLS 15.20.2]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-15.html#jls-15.20.2
-[JLS 4.10.4]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.10.4
-[JLS 4.10]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.10
-[JLS 4.3.4]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.3.4
-[JLS 4.4]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.4
-[JLS 4.5.1]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.5.1
-[JLS 4.5.2]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.5.2
-[JLS 4.5]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.5
-[JLS 4.9]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.9
-[JLS 4]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html
-[JLS 5.1.10]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-5.html#jls-5.1.10
-[JLS 8.4.1]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-8.html#jls-8.4.1
-[JLS 8.4.8.1]: https://docs.oracle.com/javase/specs/jls/se23/html/jls-8.html#jls-8.4.8.1
-[JVMS 5.4.5]: https://docs.oracle.com/javase/specs/jvms/se14/html/jvms-5.html#jvms-5.4.5
+[Java SE 23]: https://docs.oracle.com/javase/specs/jls/se26/html/index.html
+[JLS 1.3]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-1.html#jls-1.3
+[JLS 15.16]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-15.html#jls-15.16
+[JLS 15.20.2]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-15.html#jls-15.20.2
+[JLS 4.10.4]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.10.4
+[JLS 4.10]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.10
+[JLS 4.3.4]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.3.4
+[JLS 4.4]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.4
+[JLS 4.5.1]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.5.1
+[JLS 4.5.2]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.5.2
+[JLS 4.5]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.5
+[JLS 4.9]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.9
+[JLS 4]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html
+[JLS 5.1.10]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-5.html#jls-5.1.10
+[JLS 8.4.1]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-8.html#jls-8.4.1
+[JLS 8.4.8.1]: https://docs.oracle.com/javase/specs/jls/se26/html/jls-8.html#jls-8.4.8.1
 [`FluentIterable<E>`]: https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/collect/FluentIterable.html
 [all worlds]: #multiple-worlds
 [all-worlds]: #multiple-worlds
@@ -1187,8 +1186,8 @@ If a type usage is the parameter of `equals(Object)` in a subclass of
 [nullness-delegating subtyping]: #nullness-delegating-subtyping
 [nullness-subtype-establishing direct-supertype edges]: #nullness-subtype-establishing-direct-supertype-edges
 [nullness-subtype-establishing path]: #nullness-subtype-establishing-path
-[pattern]: https://docs.oracle.com/en/java/javase/23/language/pattern-matching.html
-[repeatable]: https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/lang/annotation/Repeatable.html
+[pattern]: https://docs.oracle.com/en/java/javase/26/language/pattern-matching.html
+[repeatable]: https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/lang/annotation/Repeatable.html
 [same type]: #same-type
 [same-type]: #same-type
 [semantics]: #semantics

--- a/docs/locale/ja/LC_MESSAGES/tsttcpw.po
+++ b/docs/locale/ja/LC_MESSAGES/tsttcpw.po
@@ -244,7 +244,7 @@ msgstr ""
 msgid ""
 "This definition of “enclosing” likely matches `the definition in the Java"
 " compiler API "
-"<https://docs.oracle.com/en/java/javase/14/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement()>`__."
+"<https://docs.oracle.com/en/java/javase/26/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement()>`__."
 msgstr ""
 
 #: ../../tsttcpw.rst:138
@@ -332,7 +332,7 @@ msgid ""
 "supports multiple types. Then the intersection type is derived from "
 "those. Intersection types can also arise from operations like `capture "
 "conversion <#capture-conversion>`__. See `JLS 4.9 "
-"<https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.9>`__."
+"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.9>`__."
 msgstr ""
 
 #: ../../tsttcpw.rst:199
@@ -381,7 +381,7 @@ msgid ""
 "In source, an unbounded wildcard is written as ``<?>``. This section does"
 " **not** apply to ``<? extends Object>``, even though that is often "
 "equivalent to ``<?>``. See `JLS 4.5.1 "
-"<https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.5.1>`__."
+"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.5.1>`__."
 msgstr ""
 
 #: ../../tsttcpw.rst:235
@@ -454,7 +454,7 @@ msgstr ""
 #: ../../tsttcpw.rst:277
 msgid ""
 "See `JLS 4.4 "
-"<https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.4>`__."
+"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.4>`__."
 msgstr ""
 
 #: ../../tsttcpw.rst:280
@@ -648,7 +648,7 @@ msgstr ""
 #: ../../tsttcpw.rst:402
 msgid ""
 "The Java subtyping rules are defined in `JLS 4.10 "
-"<https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.10>`__."
+"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.10>`__."
 " We add to them as follows:"
 msgstr ""
 
@@ -907,7 +907,7 @@ msgstr ""
 #: ../../tsttcpw.rst:553
 msgid ""
 "The Java rules are defined in `JLS 4.5.1 "
-"<https://docs.oracle.com/javase/specs/jls/se22/html/jls-4.html#jls-4.5.1>`__."
+"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.5.1>`__."
 " We add to them as follows:"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgstr ""
 msgid ""
 "Substitution on Java base types barely requires an explanation: See `JLS "
 "1.3 "
-"<https://docs.oracle.com/javase/specs/jls/se22/html/jls-1.html#jls-1.3>`__."
+"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-1.html#jls-1.3>`__."
 " Substitution on `augmented types <#augmented-type>`__, however, is "
 "trickier: If ``Map.get`` returns “``V`` with `nullness operator "
 "<#nullness-operator>`__ ``UNION_NULL``,” and if a user has a map whose "
@@ -1101,7 +1101,7 @@ msgstr ""
 #: ../../tsttcpw.rst:673
 msgid ""
 "The Java rules are defined in `JLS 5.1.10 "
-"<https://docs.oracle.com/javase/specs/jls/se22/html/jls-5.html#jls-5.1.10>`__."
+"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-5.html#jls-5.1.10>`__."
 " We add to them as follows:"
 msgstr ""
 

--- a/docs/locale/ja/LC_MESSAGES/tsttcpw.po
+++ b/docs/locale/ja/LC_MESSAGES/tsttcpw.po
@@ -244,7 +244,7 @@ msgstr ""
 msgid ""
 "This definition of “enclosing” likely matches `the definition in the Java"
 " compiler API "
-"<https://docs.oracle.com/en/java/javase/26/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement()>`__."
+"<https://docs.oracle.com/en/java/javase/23/docs/api/java.compiler/javax/lang/model/element/Element.html#getEnclosingElement()>`__."
 msgstr ""
 
 #: ../../tsttcpw.rst:138
@@ -332,7 +332,7 @@ msgid ""
 "supports multiple types. Then the intersection type is derived from "
 "those. Intersection types can also arise from operations like `capture "
 "conversion <#capture-conversion>`__. See `JLS 4.9 "
-"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.9>`__."
+"<https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.9>`__."
 msgstr ""
 
 #: ../../tsttcpw.rst:199
@@ -381,7 +381,7 @@ msgid ""
 "In source, an unbounded wildcard is written as ``<?>``. This section does"
 " **not** apply to ``<? extends Object>``, even though that is often "
 "equivalent to ``<?>``. See `JLS 4.5.1 "
-"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.5.1>`__."
+"<https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.5.1>`__."
 msgstr ""
 
 #: ../../tsttcpw.rst:235
@@ -454,7 +454,7 @@ msgstr ""
 #: ../../tsttcpw.rst:277
 msgid ""
 "See `JLS 4.4 "
-"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.4>`__."
+"<https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.4>`__."
 msgstr ""
 
 #: ../../tsttcpw.rst:280
@@ -648,7 +648,7 @@ msgstr ""
 #: ../../tsttcpw.rst:402
 msgid ""
 "The Java subtyping rules are defined in `JLS 4.10 "
-"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.10>`__."
+"<https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.10>`__."
 " We add to them as follows:"
 msgstr ""
 
@@ -907,7 +907,7 @@ msgstr ""
 #: ../../tsttcpw.rst:553
 msgid ""
 "The Java rules are defined in `JLS 4.5.1 "
-"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-4.html#jls-4.5.1>`__."
+"<https://docs.oracle.com/javase/specs/jls/se23/html/jls-4.html#jls-4.5.1>`__."
 " We add to them as follows:"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgstr ""
 msgid ""
 "Substitution on Java base types barely requires an explanation: See `JLS "
 "1.3 "
-"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-1.html#jls-1.3>`__."
+"<https://docs.oracle.com/javase/specs/jls/se23/html/jls-1.html#jls-1.3>`__."
 " Substitution on `augmented types <#augmented-type>`__, however, is "
 "trickier: If ``Map.get`` returns “``V`` with `nullness operator "
 "<#nullness-operator>`__ ``UNION_NULL``,” and if a user has a map whose "
@@ -1101,7 +1101,7 @@ msgstr ""
 #: ../../tsttcpw.rst:673
 msgid ""
 "The Java rules are defined in `JLS 5.1.10 "
-"<https://docs.oracle.com/javase/specs/jls/se26/html/jls-5.html#jls-5.1.10>`__."
+"<https://docs.oracle.com/javase/specs/jls/se23/html/jls-5.html#jls-5.1.10>`__."
 " We add to them as follows:"
 msgstr ""
 

--- a/src/main/java/org/jspecify/annotations/NullMarked.java
+++ b/src/main/java/org/jspecify/annotations/NullMarked.java
@@ -86,7 +86,7 @@ import java.lang.annotation.Target;
  *
  * <ul>
  *   <li>To apply this annotation to an entire (single) <b>package</b>, create a <a
- *       href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-7.html#jls-7.4.1">{@code
+ *       href="https://docs.oracle.com/javase/specs/jls/se26/html/jls-7.html#jls-7.4.1">{@code
  *       package-info.java}</a> file there. This is recommended so that newly-created classes will
  *       be null-marked by default. This annotation has no effect on "subpackages". <b>Warning</b>:
  *       if the package does not belong to a module, be very careful: it can easily happen that

--- a/src/main/java/org/jspecify/annotations/Nullable.java
+++ b/src/main/java/org/jspecify/annotations/Nullable.java
@@ -92,7 +92,7 @@ import java.lang.annotation.Target;
  *       generated accessor method as well. If an explicit accessor method is provided for this
  *       record component, it must still be annotated explicitly. Any non-null components should be
  *       checked (for example using {@link java.util.Objects#requireNonNull}) in a <a
- *       href="https://docs.oracle.com/en/java/javase/19/language/records.html">compact
+ *       href="https://docs.oracle.com/en/java/javase/26/language/records.html">compact
  *       constructor</a>.
  * </ul>
  *
@@ -121,7 +121,7 @@ import java.lang.annotation.Target;
  *   <li>On any part of the argument to <b>{@code instanceof}</b>. The root type is intrinsically
  *       non-null, as discussed above, and nothing else about nullness is checked at runtime.
  *   <li>On any part of a <b>receiver parameter</b> type (<a
- *       href="https://docs.oracle.com/javase/specs/jls/se22/html/jls-8.html#jls-8.4">JLS 8.4</a>).
+ *       href="https://docs.oracle.com/javase/specs/jls/se26/html/jls-8.html#jls-8.4">JLS 8.4</a>).
  *   <li>If both {@code @Nullable} and {@code @NonNull} appear on the same type usage,
  *       <i>neither</i> one is recognized.
  * </ul>


### PR DESCRIPTION
We should probably get in the habit of bumping these at the same time as we bump the version we use to generate Javadoc (as done in PRs like https://github.com/jspecify/jspecify/pull/793).
