### PR TITLE
Create a `projection` anchor in `Nullable`, and use `##` links.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ apply from: "gradle/format.gradle"
 apply from: "gradle/publish.gradle"
 
 java {
-    if (javaVersion.canCompileOrRun(15)) {
+    if (javaVersion.canCompileOrRun(21)) {
         withJavadocJar()
     }
     withSourcesJar()

--- a/src/main/java/org/jspecify/annotations/NonNull.java
+++ b/src/main/java/org/jspecify/annotations/NonNull.java
@@ -79,16 +79,16 @@ import java.lang.annotation.Target;
  * <p>If {@code E} has a non-null upper bound, then the apparent projection {@code @NonNull E} is
  * redundant but harmless.
  *
- * <p><a href="Nullable.html#projection">Nullable projection</a> serves the equivalent purpose in
- * the opposite direction, and is far more commonly useful.
+ * <p>{@linkplain Nullable##projection Nullable projection} serves the equivalent purpose in the
+ * opposite direction, and is far more commonly useful.
  *
  * <p>If a type variable has <i>all</i> its usages being projected in one direction or the other, it
  * should be given a non-null upper bound, and any non-null projections can then be removed.
  *
  * <h2>Where it is applicable</h2>
  *
- * <p>{@code @NonNull} is applicable in all the <a href="Nullable.html#applicability">same
- * locations</a> as {@link Nullable}.
+ * <p>{@code @NonNull} is applicable in all the {@linkplain Nullable##applicability same locations}
+ * as {@link Nullable}.
  */
 @Documented
 @Target(TYPE_USE)

--- a/src/main/java/org/jspecify/annotations/NullMarked.java
+++ b/src/main/java/org/jspecify/annotations/NullMarked.java
@@ -64,8 +64,8 @@ import java.lang.annotation.Target;
  *             href="https://bit.ly/3ppb8ZC">Why?</a>)
  *       </ul>
  *   <li>Otherwise, being null-marked has no consequence for any type usage where {@code @Nullable}
- *       and {@code @NonNull} are <a href="Nullable.html#applicability"><b>not applicable</b></a>,
- *       such as the root type of a local variable declaration.
+ *       and {@code @NonNull} are {@linkplain Nullable##applicability <b>not applicable</b>}, such
+ *       as the root type of a local variable declaration.
  *   <li>When a type variable has a nullable upper bound, such as the {@code E} in {@code class
  *       Foo<E extends @Nullable Bar>}), an unannotated usage of this type variable is not
  *       considered nullable, non-null, or even of "unspecified" nullness. Rather it has

--- a/src/main/java/org/jspecify/annotations/NullUnmarked.java
+++ b/src/main/java/org/jspecify/annotations/NullUnmarked.java
@@ -52,8 +52,8 @@ import java.lang.annotation.Target;
  * {@code @NullMarked}-annotated element, or neither annotation is present on any enclosing element.
  * No distinction is made between these cases.
  *
- * <p>The effects of being null-marked are described in the <a
- * href="NullMarked.html#effects">Effects</a> section of {@code NullMarked}.
+ * <p>The effects of being null-marked are described in the {@linkplain NullMarked##effects Effects}
+ * section of {@code NullMarked}.
  *
  * <h2>Unspecified nullness</h2>
  *
@@ -72,7 +72,7 @@ import java.lang.annotation.Target;
  *
  * <h2>Where it can be used</h2>
  *
- * The information in the <a href="NullMarked.html#where">Where it can be used</a> section of {@code
+ * The information in the {@linkplain NullMarked##where Where it can be used} section of {@code
  * NullMarked} applies as well to this annotation.
  */
 // TODO(kevinb9n): word the middle section better with good words

--- a/src/main/java/org/jspecify/annotations/Nullable.java
+++ b/src/main/java/org/jspecify/annotations/Nullable.java
@@ -73,17 +73,17 @@ import java.lang.annotation.Target;
  *       extends @Nullable Object>}. This means that a <i>type argument</i> supplied for that type
  *       parameter is permitted to be nullable if desired: {@code List<@Nullable String>}. (A
  *       non-null type argument, as in {@code List<String>}, is permitted either way.)
- *   <li>On a usage of a <b>type variable</b>: A type parameter, like the {@code E} in {@code
- *       interface List<E>}, defines a "type variable" of the same name, usable only <i>within</i>
- *       the scope of the declaring API element. In any example using {@code String} above, a type
- *       variable like {@code E} might appear instead. {@code @Nullable} continues to mean "or null"
- *       as always, but notably, this works without regard to whether the type argument is
- *       <i>already</i> nullable. For example, suppose that {@code class Foo<E extends @Nullable
- *       Object>} has a method {@code @Nullable E eOrNull()}. Then, whether {@code foo} is of type
- *       {@code Foo<String>} or {@code Foo<@Nullable String>}, the expression {@code foo.eOrNull()}
- *       is nullable either way. Using {@code @Nullable E} in this way is called "nullable
- *       projection" (<a href="NonNull.html#projection">non-null projection</a> is likewise
- *       supported, but less commonly useful).
+ *   <li><span id="projection">On a usage of a <b>type variable</b>:</span> A type parameter, like
+ *       the {@code E} in {@code interface List<E>}, defines a "type variable" of the same name,
+ *       usable only <i>within</i> the scope of the declaring API element. In any example using
+ *       {@code String} above, a type variable like {@code E} might appear instead.
+ *       {@code @Nullable} continues to mean "or null" as always, but notably, this works without
+ *       regard to whether the type argument is <i>already</i> nullable. For example, suppose that
+ *       {@code class Foo<E extends @Nullable Object>} has a method {@code @Nullable E eOrNull()}.
+ *       Then, whether {@code foo} is of type {@code Foo<String>} or {@code Foo<@Nullable String>},
+ *       the expression {@code foo.eOrNull()} is nullable either way. Using {@code @Nullable E} in
+ *       this way is called "nullable projection" ({@linkplain NonNull##projection non-null
+ *       projection} is likewise supported, but less commonly useful).
  *   <li>On a <b>nested type</b>: In most examples above, in place of {@code String} we might use a
  *       nested type such as {@code Map.Entry}. The Java syntax for annotating such a type as
  *       nullable looks like {@code Map.@Nullable Entry}.


### PR DESCRIPTION
Currently, `NonNull` links to `Nullable.html#projection`, but there is no such anchor by that name. I've added one at the definition. This is still not as clear as having a section would be, but I'm not sure whether we want a section. Another option would be to change the text in `NonNull` to refer to "nullable projection" as...

```
"when `Nullable` is [applied to](Nullable#meaning-per-each-kind-of-type-usage-heading) a type variable
```

...or something to that effect.

(For the anchor, I introduced a `span`. If I make it completely empty, then I get a warning from Javadoc. Thus, I decided to make it cover the "title" of the list item.)

As for using [`##` links](https://docs.oracle.com/en/java/javase/26/docs/specs/javadoc/doc-comment-spec.html#:~:text=references%20to%20arbitrary%20URI%20fragments): That's what I had come here to do before I found the problem with `#projection`. Compare https://github.com/google/guava/pull/8346. From what I've seen, their main advantage is when linking to other projects (since you can link to, say, `Character##supplementary` instead of `https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/lang/Character.html#supplementary`. But I figure we might as well use them for links inside JSpecify, too.
