### PR TITLE
Mostly ignore the developer's JDK in favor of using 26 (and additional testing under 9).

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,22 +21,15 @@ defaults:
 
 jobs:
   build:
-    name: JDK ${{ matrix.java_version }}
+    name: Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java_version: [11, 17, 21]
-        experimental: [false]
-    env:
-      JAVA_VERSION: ${{ matrix.java_version }}
-    continue-on-error: ${{ matrix.experimental }}
     steps:
       - uses: actions/checkout@v7
-      - name: Set up JDK ${{ matrix.java_version }}
+      - name: Set up JDK
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: ${{ matrix.java_version }}
+          java-version: 26
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
       - run: |

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
 
 repositories { mavenCentral() }
 
-def javaVersion = JavaLanguageVersion.of(System.env.JAVA_VERSION ?: 11)
+def javaVersion = JavaLanguageVersion.of(26)
 java.toolchain.languageVersion = javaVersion
 
 apply from: "gradle/mrjar.gradle"

--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -60,10 +60,24 @@ integrationTestOnJava8.configure {
     }
 }
 
+def integrationTestOnJava9 = tasks.register("integrationTestOnJava9", Test)
+integrationTestOnJava9.configure {
+    group = 'Verification'
+    description = 'Runs the integration tests with JDK9, to verify the support for Java 9.'
+
+    classpath = sourceSets.integrationTest.runtimeClasspath
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    useJUnitPlatform()
+
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(9)
+    }
+}
+
 def integrationTest = tasks.register("integrationTest", Test)
 integrationTest.configure {
     group = 'Verification'
-    description = 'Runs the integration tests with JDK9+, to verify the support for Java without jigsaw.'
+    description = "Runs the integration tests with our build's default JDK toolchain, which we keep close to the newest version, to verify support for that version."
 
     classpath = sourceSets.integrationTest.runtimeClasspath
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
@@ -73,4 +87,5 @@ integrationTest.configure {
 tasks.named('check').configure {
     dependsOn integrationTest
     dependsOn integrationTestOnJava8
+    dependsOn integrationTestOnJava9
 }


### PR DESCRIPTION
Mostly ignore the developer's JDK in favor of using 26 (and additional testing under 9).

This PR applies 26 for javadoc, javac, and one run of our integration tests. It applies Java 9 for an additional run of our integration tests, and it keeps the existing run under Java 8.

We could consider additional testing of releases between the endpoints of Java 9 and Java 26, presumably on LTS releases 11+17+21+25, but I'm guessing it wouldn't buy us much.

Then, make the CI run Gradle under (and only 26) and stop setting `JAVA_VERSION`. That should matter little, since the other changes of this PR make us ignore the `JAVA_VERSION` environment variable (which contributed to https://github.com/jspecify/jspecify/pull/812) and the fallback default of "whichever Java version the user used to run Gradle." We do still need to keep this Java version compatible with the Gradle version that we use, but broadly, I hope to keep on the newest version of each. This PR does let us advance our toolchain version (javadoc+javac+testing) ahead of the version we use to run Gradle if we find that useful at some point.

We should bump the "26" in both `build.gradle` and `.github/workflows/build.yml` whenever we [bump the Java version elsewhere](https://github.com/jspecify/jspecify/pull/815). As noted above, we can bump one before the other if necessary.

(I notice that we don't have any [required status checks](https://github.com/jspecify/jspecify/settings/branch_protection_rules/34801738), even though we have "Require status checks to pass before merging" checked. Maybe I'll register at least the new One True "Build" check after I merge this PR.)

- Fixes https://github.com/jspecify/jspecify/issues/271 (by following https://jakewharton.com/build-on-latest-java-test-through-lowest-java/)
- Fixes https://github.com/jspecify/jspecify/issues/813
- Would have avoided the need for https://github.com/jspecify/jspecify/pull/812
- Slightly simplifies https://github.com/jspecify/jspecify/issues/305