### PR TITLE
List lambda parameter types as a recognized location.

### DIFF
--- a/docs/docs/spec.md
+++ b/docs/docs/spec.md
@@ -224,6 +224,8 @@ exceptions in the subsequent sections:
     > varargs methods). For examples of variadic parameters, see the comment
     > about array components below.
 
+-   a formal parameter type of a lambda
+
 -   a field type
 
 -   a record component type


### PR DESCRIPTION
This was our decision back in https://github.com/jspecify/jspecify/issues/261, but we missed it in the spec until @kevinb9n pointed it out today.

Hopefully it's [the only true mistake in this section](https://github.com/jspecify/jspecify/issues/821).
