### PR TITLE
Produce a Javadoc jar unconditionally.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,9 +37,7 @@ apply from: "gradle/format.gradle"
 apply from: "gradle/publish.gradle"
 
 java {
-    if (javaVersion.canCompileOrRun(21)) {
-        withJavadocJar()
-    }
+    withJavadocJar()
     withSourcesJar()
 
     sourceCompatibility = 8


### PR DESCRIPTION
Previously, the check was conditional on the Java toolchain that we configured above. But as of https://github.com/jspecify/jspecify/pull/818, that toolchain has always been 26, so the check has been trivially true. Thanks to @wmdietl for calling out this weirdness during the review of https://github.com/jspecify/jspecify/pull/816.
