### PR TITLE
Explicitly include `maven-publish` in `conformance-tests`.

### DIFF
--- a/conformance-tests/build.gradle
+++ b/conformance-tests/build.gradle
@@ -19,6 +19,7 @@ import org.gradle.api.JavaVersion
 plugins {
     id 'java-library'
     id 'distribution'
+    id 'maven-publish'
 }
 
 group = 'org.jspecify.conformance'


### PR DESCRIPTION
This prepares for Gradle 10 by resolving a deprecation warning, which I needed to include `--no-configuration-cache` to reliably see:

```
$ ./gradlew clean javadoc --warning-mode all --no-configuration-cache

> Configure project :conformance-tests
Build file '/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/conformance-tests/build.gradle': line 81
Implicit lookup of methods in parent projects has been deprecated. This will fail with an error in Gradle 10. Method 'publishing' was not declared in project ':conformance-tests' and was resolved from root project 'jspecify'. Consult the upgrading guide for further information: https://docs.gradle.org/9.6.1/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects
        at build_27racyxjzih8dgczrw9t4dzv4.run(/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/conformance-tests/build.gradle:81)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```
