### PR TITLE
Document `npm run serve` and `./gradlew buildDocs`, including advantages over `npm start`.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,9 @@
 # Website
 
-This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus](https://docusaurus.io/), a modern
+static website generator.
 
-The instructions bellow assume that you're inside `docs/` directory.
+The instructions below assume that you're inside `docs/` directory.
 
 ### Installation
 
@@ -16,21 +17,56 @@ $ npm install
 $ npm start
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+This command starts a local development server and opens up a browser window.
+Most changes are reflected live without having to restart the server.
+
+The development server has a few downsides relative to a static build (an option
+that is discussed below):
+
+-   The development server does not build (or rebuild) the Javadoc.
+-   The development server is not as strict as the full build. If you see errors
+    in CI that you don't see in local development, then try a full build
+    locally.
+-   Directly opening a specific anchor in the development server (though a URL
+    such as
+    `http://localhost:3000/docs/nullness-design-faq/#unspecified-nullness`) does
+    not work. (The problem seems to be that the server first returns a skeleton
+    page (which naturally doesn't contain the anchor) and then fills in content
+    later.) If you want to test navigation to anchors, it may work if you
+    navigate by opening a link in the same tab (instead of in a new window or
+    new tab or by typing the link into the address bar). Alternatively, you can
+    build and serve the site locally.
+-   The development server is not accessible from other machines by default.
+    (You can change that by using `npm start -- --host 0.0.0.0`).
 
 ### Build
+
+```
+$ ( cd .. && ./gradlew buildDocs )
+```
+
+The command above builds the entire documentation site, including the Javadoc.
+If you aren't interested in the Javadoc, you can build only the other parts of
+the site with:
 
 ```
 $ npm run build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+Either command generates static content into the `build` directory and can be
+served using any static contents hosting service. One easy way to serve the most recently built content is:
+
+```
+$ npm run serve
+```
 
 ### Deployment
 
 The site is built and published to GitHub Pages via GitHub Actions.
 
 ### Manual Deployment
+
+(This section has not been tested recently. It may be out of date.)
 
 Using SSH:
 
@@ -44,4 +80,5 @@ Not using SSH:
 $ GIT_USER=<Your GitHub username> yarn deploy
 ```
 
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+If you are using GitHub pages for hosting, this command is a convenient way to
+build the website and push to the `gh-pages` branch.


### PR DESCRIPTION
The advantages were on display as I worked on https://github.com/jspecify/jspecify/pull/849 and https://github.com/jspecify/jspecify/pull/858.

Here's an example of an error that was caught by `./gradlew buildDocs` / `npm run build` but not `npm start`. It came from some bad link syntax when I tried to follow (roughly) `[@NullMarked]` with a parenthetical "(Why?)":

```
[ERROR] Error: Unable to build website for locale en.
    at tryToBuildLocale (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:78:15)
    at async /usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:34:9
    ... 4 lines matching cause stack trace ...
    at async file:///usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/bin/docusaurus.mjs:44:3 {
  [cause]: Error: Docusaurus found broken links!

  Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
  Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

  Exhaustive list of all broken links found:
  - Broken link on source page path = /docs/user-guide/:
     -> linking to %5BWhy/?%5D(nullness-design-faq.md#null-marked-non-null-by-default) (resolved as: /docs/user-guide/%5BWhy/?%5D(nullness-design-faq.md#null-marked-non-null-by-default))

      at throwError (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/logger/lib/logger.js:80:11)
      at reportBrokenLinks (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/server/brokenLinks.js:250:47)
      at handleBrokenLinks (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/server/brokenLinks.js:282:5)
      at executeBrokenLinksCheck (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/commands/build/buildLocale.js:91:47)
      at /usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/commands/build/buildLocale.js:70:67
      at Object.async (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/logger/lib/perfLogger.js:42:47)
      at buildLocale (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/commands/build/buildLocale.js:70:31)
      at async runBuildLocaleTask (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:93:5)
      at async /usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:74:13
      at async tryToBuildLocale (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:70:9)
      at async /usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:34:9
      at async mapAsyncSequential (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/utils/lib/jsUtils.js:21:24)
      at async Command.build (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:33:5)
      at async Promise.all (index 0)
      at async runCLI (/usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/lib/commands/cli.js:56:5)
      at async file:///usr/local/google/home/cpovirk/clients/jspecify-white/jspecify/docs/node_modules/@docusaurus/core/bin/docusaurus.mjs:44:3
```
