### PR TITLE
Bump Dependabot cooldown period from three days to seven.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7
   groups:
     dependencies:
       applies-to: version-updates
@@ -14,6 +16,8 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7
   groups:
     dependencies:
       applies-to: version-updates
@@ -24,6 +28,8 @@ updates:
   directory: "/docs"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7
   groups:
     dependencies:
       applies-to: version-updates


### PR DESCRIPTION
Three is [the default](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-).

Seven is a recommendation that I've seen a couple places, including in some Google-internal documentation. I'd hope that it would never make a difference in practice here either way.
