### PR TITLE
Further admit that we're using jspecify.dev more than jspecify.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An artifact of well-specified annotations to power static analysis checks and
 JVM language interop. Developed by consensus of the partner organizations listed
-at our main web site, [jspecify.org](https://jspecify.dev).
+at our main web site, [jspecify.dev](https://jspecify.dev).
 
 Our current focus is on annotations for nullness analysis.
 
@@ -14,4 +14,4 @@ finalizes our initial nullness annotations.
 
 ## Things to read
 
-See [jspecify.org/docs/start-here](https://jspecify.dev/docs/start-here).
+See [jspecify.dev/docs/start-here](https://jspecify.dev/docs/start-here).

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ node {
 
 tasks.register('buildDocs') {
     group = 'Build'
-    description = 'Builds the jspecify.org website.'
+    description = 'Builds the jspecify.dev website.'
     dependsOn('npm_run_build')
     dependsOn('javadoc')
 }


### PR DESCRIPTION
We still hope to someday figure out the SSL setup for jspecify.org, which merely redirects to jspecify.dev but which produces a warning along the way. But it's no one's area of expertise in our group.
