### PR TITLE
Update docs for JSpecify 1.0.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Our current focus is on annotations for nullness analysis.
 
 ## Status
 
-We've released
-[Version 1.0.0](https://github.com/jspecify/jspecify/releases/tag/v1.0.0), which
-finalizes our initial nullness annotations.
+We have finalized and released our initial nullness annotations. Our latest
+release is
+[Version 1.0.1](https://github.com/jspecify/jspecify/releases/tag/v1.0.1).
 
 ## Things to read
 

--- a/docs/docs/start-here.md
+++ b/docs/docs/start-here.md
@@ -122,7 +122,7 @@ videos:
 [faq]: http://github.com/jspecify/jspecify/wiki/jspecify-faq
 [nullness design faq]: https://github.com/jspecify/jspecify/wiki/nullness-design-FAQ
 [issues]: https://github.com/jspecify/jspecify/issues
-[release]: https://search.maven.org/artifact/org.jspecify/jspecify/1.0.0/jar
+[release]: https://central.sonatype.com/artifact/org.jspecify/jspecify/1.0.1
 [reference implementation]: https://github.com/jspecify/jspecify-reference-checker
 [spec]: /docs/spec
 [stackoverflow answer]: https://stackoverflow.com/questions/4963300/which-notnull-java-annotation-should-i-use

--- a/docs/docs/using.md
+++ b/docs/docs/using.md
@@ -7,7 +7,7 @@ sidebar_position: 4
 ## Depending on the annotations
 
 The annotations are available from Maven Central as
-[`org.jspecify:jspecify:1.0.0`](https://repo1.maven.org/maven2/org/jspecify/jspecify/1.0.0/).
+[`org.jspecify:jspecify:1.0.1`](https://repo1.maven.org/maven2/org/jspecify/jspecify/1.0.1/).
 The annotations themselves are in the `org.jspecify.annotations` package.
 
 Below are snippets you can use to add a dependency in Maven, Gradle, or Bazel.
@@ -25,7 +25,7 @@ guidance below.
 <dependency>
   <groupId>org.jspecify</groupId>
   <artifactId>jspecify</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
 </dependency>
 ```
 
@@ -40,7 +40,7 @@ plugins, use the `api` configuration rather than the [`implementation`] or
 
 ```groovy
 dependencies {
-  api("org.jspecify:jspecify:1.0.0")
+  api("org.jspecify:jspecify:1.0.1")
 }
 ```
 
@@ -49,7 +49,7 @@ as the `java` plugin:
 
 ```groovy
 dependencies {
-  implementation("org.jspecify:jspecify:1.0.0")
+  implementation("org.jspecify:jspecify:1.0.1")
 }
 ```
 
@@ -58,7 +58,7 @@ dependencies {
 ```python
 maven_jar(
     name = "jspecify",
-    artifact = "org.jspecify:jspecify:1.0.0",
+    artifact = "org.jspecify:jspecify:1.0.1",
     sha256 = "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
 )
 ```


### PR DESCRIPTION
DO NOT MERGE until after:

- publishing the release
- updating the `sha256` value in docs/docs/using.md. (See also https://github.com/jspecify/jspecify/issues/856.)
