### PR TITLE
Migrate to `com.vanniktech.maven.publish`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,10 +53,10 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Publish conformance tests snapshot
-        run: ./gradlew publishConformanceTestsPublicationToSonatypeRepository --no-configuration-cache
+        run: ./gradlew publishConformanceTestsPublicationToMavenCentralRepository --no-configuration-cache
         env:
-          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.sonatype_username }}
-          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.sonatype_password }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.sonatype_username }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.sonatype_password }}
 
   reference-checker-tests:
     name: Run Reference Checker Tests

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'java-library'
     id 'com.diffplug.spotless' version '8.8.0'
     id 'com.github.node-gradle.node' version '7.1.0'
-    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0' apply false
+    id 'com.vanniktech.maven.publish' version '0.37.0'
     id 'biz.aQute.bnd.builder' version '7.3.0'
 }
 
@@ -37,16 +37,11 @@ apply from: "gradle/format.gradle"
 apply from: "gradle/publish.gradle"
 
 java {
-    if (javaVersion.canCompileOrRun(21)) {
-        withJavadocJar()
-    }
-    withSourcesJar()
-
     sourceCompatibility = 8
     targetCompatibility = 8
     // but compile against newer JDK libraries so that we can use @Target({..., MODULE})
 
-    tasks.named('sourcesJar') {
+    tasks.matching { it.name == 'sourcesJar' }.configureEach {
         exclude('**.class')
     }
 }

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -18,63 +18,49 @@
 
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
+apply plugin: 'com.vanniktech.maven.publish'
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            pom {
-                groupId = 'org.jspecify'
-                artifactId = 'jspecify'
-                name = 'JSpecify annotations'
-                description = 'An artifact of well-named and well-specified annotations to power static analysis checks'
-                url = 'https://jspecify.dev/'
-                from components.java
-                licenses {
-                    license {
-                        name = 'The Apache License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-                scm {
-                    connection = 'scm:git:git@github.com:jspecify/jspecify.git'
-                    developerConnection = 'scm:git:git@github.com:jspecify/jspecify.git'
-                    url = 'https://github.com/jspecify/jspecify/'
-                }
-                developers {
-                    // These are here only because Sonatype requires us to list someone.
-                    // Any project member is welcome to add themselves if they want to.
-                    developer {
-                        id = 'kevinb9n'
-                        name = 'Kevin Bourrillion'
-                        email = 'kevinb9n@gmail.com'
-                    }
-                    developer {
-                        id = 'netdpb'
-                        name = 'David P. Baker'
-                        email = 'dpb@google.com'
-                        organization = 'Google'
-                        timezone = 'America/New_York'
-                    }
-                    developer {
-                        id = 'cpovirk'
-                        name = 'Chris Povirk'
-                        email = 'cpovirk@google.com'
-                        organization = 'Google'
-                        timezone = 'America/New_York'
-                    }
-                }
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+
+    pom {
+        name = 'JSpecify annotations'
+        description = 'An artifact of well-named and well-specified annotations to power static analysis checks'
+        url = 'https://jspecify.dev/'
+        licenses {
+            license {
+                name = 'The Apache License, Version 2.0'
+                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
             }
         }
-    }
-}
-
-nexusPublishing {
-    repositories {
-        // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        scm {
+            connection = 'scm:git:git@github.com:jspecify/jspecify.git'
+            developerConnection = 'scm:git:git@github.com:jspecify/jspecify.git'
+            url = 'https://github.com/jspecify/jspecify/'
+        }
+        developers {
+            // These are here only because Sonatype requires us to list someone.
+            // Any project member is welcome to add themselves if they want to.
+            developer {
+                id = 'kevinb9n'
+                name = 'Kevin Bourrillion'
+                email = 'kevinb9n@gmail.com'
+            }
+            developer {
+                id = 'netdpb'
+                name = 'David P. Baker'
+                email = 'dpb@google.com'
+                organization = 'Google'
+                timezone = 'America/New_York'
+            }
+            developer {
+                id = 'cpovirk'
+                name = 'Chris Povirk'
+                email = 'cpovirk@google.com'
+                organization = 'Google'
+                timezone = 'America/New_York'
+            }
         }
     }
 }
@@ -84,7 +70,6 @@ def pgpPassword = findProperty('pgpPassword')
 
 signing {
     useInMemoryPgpKeys(privateKey, pgpPassword)
-    sign publishing.publications.mavenJava
 }
 
 tasks.withType(Sign).configureEach {


### PR DESCRIPTION
(It sets up `withJavadocJar()` and `withSourcesJar()` automatically.)

I used this to publish release 1.0.1.

Fixes https://github.com/jspecify/jspecify/pull/827 (by eliminating that section entirely)