### PR TITLE
Fix Zizmor warnings about GitHub Actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,14 +24,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422/
         with:
           distribution: temurin
           java-version: 26
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92/
       - run: |
           ./gradlew spotlessCheck build publishToMavenLocal --no-daemon
 
@@ -44,14 +44,14 @@ jobs:
       JAVA_VERSION: 17
     steps:
       - name: Check out the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422/
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92/
       - name: Publish conformance tests snapshot
         run: ./gradlew publishConformanceTestsPublicationToSonatypeRepository --no-configuration-cache
         env:
@@ -66,21 +66,21 @@ jobs:
       JAVA_VERSION: 17
     steps:
       - name: Check out the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           path: jspecify
       - name: Check out the reference checker
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: ${{ github.repository_owner }}/${{ env.reference_checker_repo }}
           path: ${{ env.reference_checker_repo }}
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422/
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92/
       - name: Run Conformance Tests
         if: github.base_ref == 'main' # only PRs onto main
         continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,12 +26,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Set up JDK
-        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422/
+        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422
         with:
           distribution: temurin
           java-version: 26
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92/
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92
       - run: |
           ./gradlew spotlessCheck build publishToMavenLocal --no-daemon
 
@@ -46,12 +46,12 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - name: Set up Java
-        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422/
+        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92/
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92
       - name: Publish conformance tests snapshot
         run: ./gradlew publishConformanceTestsPublicationToSonatypeRepository --no-configuration-cache
         env:
@@ -75,12 +75,12 @@ jobs:
           repository: ${{ github.repository_owner }}/${{ env.reference_checker_repo }}
           path: ${{ env.reference_checker_repo }}
       - name: Set up Java
-        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422/
+        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92/
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92
       - name: Run Conformance Tests
         if: github.base_ref == 'main' # only PRs onto main
         continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422
         with:
@@ -45,6 +47,8 @@ jobs:
     steps:
       - name: Check out the code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Set up Java
         uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422
         with:
@@ -69,11 +73,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           path: jspecify
+          persist-credentials: false
       - name: Check out the reference checker
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: ${{ github.repository_owner }}/${{ env.reference_checker_repo }}
           path: ${{ env.reference_checker_repo }}
+          persist-credentials: false
       - name: Set up Java
         uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ defaults:
   run:
     shell: bash --noprofile --norc -e -o pipefail -x {0}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,13 +38,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Set up Java
-        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422/
+        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92/
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92
 
       - name: Build docs
         run: ./gradlew buildDocs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,9 @@ on:
       - 'src/main/**'
       - 'src/java9/**'
 
+permissions:
+  contents: read
+
 jobs:
   # Runs on PRs and push to ensure the documentation successfully builds.
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,22 +35,22 @@ jobs:
       JAVA_VERSION: 26
     steps:
       - name: Check out project
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422/
         with:
           distribution: temurin
           java-version: ${{ env.JAVA_VERSION }}
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92/
 
       - name: Build docs
         run: ./gradlew buildDocs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: docs/build
 
@@ -74,4 +74,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Check out project
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Set up Java
         uses: actions/setup-java@e498d2a66a953492f322542257b22125c989b422

--- a/.github/workflows/update-conformance-test-reports.yml
+++ b/.github/workflows/update-conformance-test-reports.yml
@@ -20,6 +20,8 @@ defaults:
   run:
     shell: bash --noprofile --norc -e -o pipefail -x {0}
 
+permissions: {}
+
 jobs:
   udpate-reference-checker-reports:
     name: Update reference checker conformance test reports if necessary


### PR DESCRIPTION
This addresses ["unpinned action reference"](https://docs.zizmor.sh/audits/#unpinned-uses) warnings [seen](https://github.com/jspecify/jspecify/actions/runs/30497738162/job/90730495179) during https://github.com/jspecify/jspecify/pull/860.

I thought I would be all clever and automate it:

```
for F in $(grep -hoP 'uses: \K.*' .github/workflows/*.yml | sort -u); do R=${F%@*}; V=${F#*@}; git ls-remote https://github.com/${R}.git ${V} | awk '{ print $1 }'; done
```

But that's wrong for setup-gradle. I looked that one up manually (https://github.com/gradle/actions/releases/tag/v6.2.0 -> https://github.com/gradle/actions/commit/3f131e8634966bd73d06cc69884922b02e6faf92). Then:

```
perl -pi -e "s'actions/checkout@v7'actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1'; s'actions/deploy-pages@v5'actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128'; s'actions/setup-java@v5'actions/setup-java@e498d2a66a953492f322542257b22125c989b422'; s'actions/upload-pages-artifact@v5'actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9'; s'gradle/actions/setup-gradle@v6'gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92'" .github/workflows/*.yml
```

\[edit: And then I had some typos in this second command. I have manually fixed the results and tried to update the regex here.\]

I could instead have tried to install zizmor locally and run [its fix mode](https://docs.zizmor.sh/usage/#auto-fixing-results).
