### PR TITLE
Enable configuration cache when publishing conformance-test snapshots.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
       - name: Publish conformance tests snapshot
-        run: ./gradlew publishConformanceTestsPublicationToSonatypeRepository --no-configuration-cache
+        run: ./gradlew publishConformanceTestsPublicationToSonatypeRepository
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.sonatype_username }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.sonatype_password }}


### PR DESCRIPTION
This undoes https://github.com/jspecify/jspecify/pull/769.

It is possible because we're moving off gradle-nexus/publish-plugin (which has [a problem with the configuration cache](https://github.com/gradle-nexus/publish-plugin/issues/221)) and onto `com.vanniktech.maven.publish`, which does not, in https://github.com/jspecify/jspecify/pull/860.

So DO NOT MERGE until after https://github.com/jspecify/jspecify/pull/860 and also until after https://github.com/jspecify/jspecify/pull/861 to address some warnings in our GitHub Actions configuration
