### PR TITLE
NullExclusiveThreadLocal: allow no error on incompatible lambda

### DIFF
--- a/samples/NullExclusiveThreadLocal.java
+++ b/samples/NullExclusiveThreadLocal.java
@@ -39,7 +39,7 @@ class NullExclusiveThreadLocal {
 
     ThreadLocal<Object> x5 = ThreadLocal.withInitial(() -> "");
 
-    // :: error: jspecify_nullness_mismatch
+    // :: error: jspecify_nullness_mismatch jspecify_but_expect_nothing
     ThreadLocal.withInitial(() -> null);
   }
 


### PR DESCRIPTION
This is the last genuine problem with the EISOP version. For now, allow no error being issued for this line.