### PR TITLE
NullnessUnspecifiedTypeParameter: also allow error on variable declaration

### DIFF
--- a/samples/nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java
+++ b/samples/nullnessUnspecifiedTypeParameter/nullnessunspecifiedtypeparameter/NullnessUnspecifiedTypeParameter.java
@@ -31,6 +31,7 @@ class Test {}
 class Instances {
   static final NullnessUnspecifiedTypeParameter<Object> A1 =
       new NullnessUnspecifiedTypeParameter<>();
+  // :: error: jspecify_nullness_mismatch
   static final NullnessUnspecifiedTypeParameter<@Nullable Object> A2 =
       // :: error: jspecify_nullness_mismatch
       new NullnessUnspecifiedTypeParameter<>();


### PR DESCRIPTION
Expect two errors:
- On the variable declaration, as the explicit type argument is invalid;
- On the object creation - the diamond is inferred from the LHS and therefore also invalid.

The second one is up for debate, but the current EISOP behavior.