### PR TITLE
Remove no longer needed `but_expect` messages

### DIFF
--- a/samples/IntersectionSupertype.java
+++ b/samples/IntersectionSupertype.java
@@ -72,17 +72,17 @@ interface IntersectionSupertype {
   default void useLibUnionNull(@Nullable Lib lib) {
     // :: error: jspecify_nullness_mismatch
     x0(lib);
-    // :: error: jspecify_nullness_mismatch jspecify_but_expect_warning
+    // :: error: jspecify_nullness_mismatch
     x1(lib);
-    // :: error: jspecify_nullness_mismatch jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_mismatch
     x2(lib);
-    // :: error: jspecify_nullness_mismatch jspecify_but_expect_warning
+    // :: error: jspecify_nullness_mismatch
     x3(lib);
     // :: error: jspecify_nullness_not_enough_information
     x4(lib);
     // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_nothing
     x5(lib);
-    // :: error: jspecify_nullness_mismatch jspecify_but_expect_nothing
+    // :: error: jspecify_nullness_mismatch
     x6(lib);
     // :: error: jspecify_nullness_not_enough_information
     x7(lib);

--- a/samples/MultiBoundTypeVariableToObject.java
+++ b/samples/MultiBoundTypeVariableToObject.java
@@ -24,17 +24,14 @@ class MultiBoundTypeVariableToObject {
   }
 
   <T extends Object & @NullnessUnspecified Lib> Object x1(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 
   <T extends Object & @Nullable Lib> Object x2(T x) {
-    // :: error: jspecify_but_expect_error
     return x;
   }
 
   <T extends @NullnessUnspecified Object & Lib> Object x3(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 
@@ -49,12 +46,11 @@ class MultiBoundTypeVariableToObject {
   }
 
   <T extends @Nullable Object & Lib> Object x6(T x) {
-    // :: error: jspecify_but_expect_error
     return x;
   }
 
   <T extends @Nullable Object & @NullnessUnspecified Lib> Object x7(T x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_error
+    // :: error: jspecify_nullness_not_enough_information
     return x;
   }
 

--- a/samples/MultiBoundTypeVariableToObjectUnspec.java
+++ b/samples/MultiBoundTypeVariableToObjectUnspec.java
@@ -24,17 +24,14 @@ class MultiBoundTypeVariableToObjectUnspec {
   }
 
   <T extends Object & @NullnessUnspecified Lib> @NullnessUnspecified Object x1(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 
   <T extends Object & @Nullable Lib> @NullnessUnspecified Object x2(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 
   <T extends @NullnessUnspecified Object & Lib> @NullnessUnspecified Object x3(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 
@@ -50,7 +47,6 @@ class MultiBoundTypeVariableToObjectUnspec {
   }
 
   <T extends @Nullable Object & Lib> @NullnessUnspecified Object x6(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 

--- a/samples/MultiBoundTypeVariableToOther.java
+++ b/samples/MultiBoundTypeVariableToOther.java
@@ -24,17 +24,14 @@ class MultiBoundTypeVariableToOther {
   }
 
   <T extends Object & @NullnessUnspecified Lib> Lib x1(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 
   <T extends Object & @Nullable Lib> Lib x2(T x) {
-    // :: error: jspecify_but_expect_error
     return x;
   }
 
   <T extends @NullnessUnspecified Object & Lib> Lib x3(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 
@@ -49,12 +46,11 @@ class MultiBoundTypeVariableToOther {
   }
 
   <T extends @Nullable Object & Lib> Lib x6(T x) {
-    // :: error: jspecify_but_expect_error
     return x;
   }
 
   <T extends @Nullable Object & @NullnessUnspecified Lib> Lib x7(T x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_error
+    // :: error: jspecify_nullness_not_enough_information
     return x;
   }
 

--- a/samples/MultiBoundTypeVariableToOtherUnspec.java
+++ b/samples/MultiBoundTypeVariableToOtherUnspec.java
@@ -24,17 +24,14 @@ class MultiBoundTypeVariableToOtherUnspec {
   }
 
   <T extends Object & @NullnessUnspecified Lib> @NullnessUnspecified Lib x1(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 
   <T extends Object & @Nullable Lib> @NullnessUnspecified Lib x2(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 
   <T extends @NullnessUnspecified Object & Lib> @NullnessUnspecified Lib x3(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 
@@ -50,7 +47,6 @@ class MultiBoundTypeVariableToOtherUnspec {
   }
 
   <T extends @Nullable Object & Lib> @NullnessUnspecified Lib x6(T x) {
-    // :: error: jspecify_but_expect_warning
     return x;
   }
 

--- a/samples/MultiBoundTypeVariableUnspecToOther.java
+++ b/samples/MultiBoundTypeVariableUnspecToOther.java
@@ -30,7 +30,7 @@ class MultiBoundTypeVariableUnspecToOther {
   }
 
   <T extends Object & @Nullable Lib> Lib x2(@NullnessUnspecified T x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_error
+    // :: error: jspecify_nullness_not_enough_information
     return x;
   }
 
@@ -51,12 +51,12 @@ class MultiBoundTypeVariableUnspecToOther {
   }
 
   <T extends @Nullable Object & Lib> Lib x6(@NullnessUnspecified T x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_error
+    // :: error: jspecify_nullness_not_enough_information
     return x;
   }
 
   <T extends @Nullable Object & @NullnessUnspecified Lib> Lib x7(@NullnessUnspecified T x) {
-    // :: error: jspecify_nullness_not_enough_information jspecify_but_expect_error
+    // :: error: jspecify_nullness_not_enough_information
     return x;
   }
 

--- a/samples/NotNullMarkedLambdaAndMethodReferenceInference.java
+++ b/samples/NotNullMarkedLambdaAndMethodReferenceInference.java
@@ -61,12 +61,6 @@ class NotNullMarkedLambdaAndMethodReferenceInference {
   abstract class User extends Super {
     void go() {
       useResult(foos().collect(collectors().partitioningBy(Foo::isBar)));
-      /*
-       * The way to fix the warning might be to make getFnInterfaceFromTree overwrite any
-       * parameters' default additional nullnesses with those from the corresponding interface's
-       * parameters. Maybe use TreeUtils.findFunction?
-       */
-      // :: error: jspecify_but_expect_warning
       useResult(foos().collect(collectors().partitioningBy(foo -> foo.isBar())));
     }
   }

--- a/samples/OptionalConversions.java
+++ b/samples/OptionalConversions.java
@@ -17,11 +17,11 @@ import com.google.common.base.Optional;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
-// The warnings below will go away once Optional is @NullMarked.
+// Because Optional isn't @NullMarked, the conversions below have unspecified nullness, and no
+// tool is obligated to report anything about them. This checker doesn't.
 @NullMarked
 class OptionalConversions {
   java.util.Optional<Foo> to0(Optional<Foo> p) {
-    // :: error: jspecify_but_expect_warning
     return Optional.toJavaUtil(p);
   }
 
@@ -31,7 +31,6 @@ class OptionalConversions {
   }
 
   Optional<Foo> from0(java.util.Optional<Foo> p) {
-    // :: error: jspecify_but_expect_warning
     return Optional.fromJavaUtil(p);
   }
 
@@ -41,7 +40,6 @@ class OptionalConversions {
   }
 
   java.util.Optional<Foo> toUsingInstanceMethod(Optional<Foo> p) {
-    // :: error: jspecify_but_expect_warning
     return p.toJavaUtil();
   }
 


### PR DESCRIPTION
Removes previously expected errors or previously missing errors. These should not be controversial.