### PR TITLE
Add explicit maven-publish plugin

### DIFF
--- a/conformance-tests/build.gradle
+++ b/conformance-tests/build.gradle
@@ -19,6 +19,7 @@ import org.gradle.api.JavaVersion
 plugins {
     id 'java-library'
     id 'distribution'
+    id 'maven-publish'
 }
 
 group = 'org.jspecify.conformance'


### PR DESCRIPTION
This fixes the following conformance test warning:

```
> Configure project :jspecify:conformance-tests
Build file '/home/wdietl/workspaces-server/claude/eisop/jspecify/conformance-tests/build.gradle': line 81
Implicit lookup of methods in parent projects has been deprecated. This will fail with an error in Gradle 10. Method 'publishing' was not declared in project ':jspecify:conformance-tests' and was resolved from project ':jspecify'. This lookup was initiated by a dynamic invocation in the build script. Consult the upgrading guide for further information: https://docs.gradle.org/9.7.0/userguide/upgrading_version_9.html#deprecated_implicit_lookup_in_parent_projects
        at build_3a4zheeesqoxf57i1wmzqup0n.run(/home/wdietl/workspaces-server/claude/eisop/jspecify/conformance-tests/build.gradle:81)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
│█████▋·········│ 37% EXECUTING [3s]
```